### PR TITLE
fix hyperlinks on readme description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
   Hellper - Your best friend in times of crisis<br>
 </h1>
 
-<div align="center">Hellper bot aims to orchestrate the process and resolution of incidents, reducing the time spent with manual tasks and ensuring that the necessary steps are fulfilled in the right order. Also, it facilitates the measurement of impact and response rate through [metrics](#metrics).
-
+<div align="center">Hellper bot aims to orchestrate the process and resolution of incidents, reducing the time spent with manual tasks and ensuring that the necessary steps are fulfilled in the right order. Also, it facilitates the measurement of impact and response rate through <a href="#metrics">metrics</a>.
   <p>A chance to help explore and develop a bot written in Go, integrated with multiple external platforms and tools.</p>
   <p>Help us expand incident processes’ and understand the needs of other companies that may benefit from Hellper bot.</p>
-  <p>You’re just one PR away from joining the developing team of Hellper! [Contribute](#contributing)</p>
+  <p>You’re just one PR away from joining the developing team of Hellper! <a href="#contributing">Contribute</a></p>
 </div>
 
 <p align="center">


### PR DESCRIPTION
### Description
Fix of hyperlinks on readme Hellper description.

![image](https://user-images.githubusercontent.com/38014417/79257472-0b506600-7e60-11ea-9673-46dd9bb69446.png)

### How to test?
Check out the Readme page.

### Expected behavior
Hyperlinks must be functional.