### PR TITLE
Create section about Google Calendar API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ cp development.env.example development.env
 |**HELLPER_DSN**|Your Data Source Name| --- |
 |**HELLPER_ENVIRONMENT**|Current environment (supported values: production, staging)| --- |
 |**HELLPER_GOOGLE_DRIVE_CREDENTIALS**|[Google Drive Credentials](/docs/CONFIGURING-GOOGLE.md#Get-a-Client-ID-and-Client-Secret)| --- |
+|**HELLPER_GOOGLE_DRIVE_TOKEN**|[Google Drive Token](/docs/CONFIGURING-GOOGLE.md#Generate-Google-Drive-access-token)|
 |**HELLPER_GOOGLE_DRIVE_FILE_ID**|[Google Drive FileId](/docs/CONFIGURING-GOOGLE.md#Template-Post-mortem) to your post-mortem template| --- |
-|**HELLPER_GOOGLE_DRIVE_TOKEN**|[Google Drive Token](/docs/CONFIGURING-GOOGLE.md#Signing-in-to-the-application)| --- |
+|**HELLPER_GOOGLE_CALENDAR_TOKEN**|[Google Calendar Token](/docs/CONFIGURING-GOOGLE.md#Generate-Google-Calendar-access-token)|
+|**HELLPER_GOOGLE_CALENDAR_ID**|[Google Calendar Id](/docs/CONFIGURING-GOOGLE.md#Obtain-your-Google-Calendar's-ID) to schedule your post-mortem |
 |**HELLPER_MATRIX_HOST**|[Matrix](https://github.com/ResultadosDigitais/matrix) URL host| --- |
 |**HELLPER_PRODUCT_CHANNEL_ID**|The Product channel id used to notify new incidents| --- |
 |**HELLPER_SUPPORT_TEAM**|Support team identifier to notify| --- |

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -36,7 +36,7 @@ The instructions here are a summary of the [official documentation](https://clou
 5. Copy the content file and paste it in your environment variable called: `HELLPER_GOOGLE_DRIVE_CREDENTIALS`.
 
 
-## Authorization requests to the Google Drive API
+## Authorizing requests to the Google Drive API
 1. Copy the **Client ID** you got in the last step (_[Credentials](#credentials)_).
 2. In the following URL, change `YOUR_CLIENT_ID_HERE` with the content from **Client ID**:
 

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -9,11 +9,12 @@ This instructions guide will give your application permission to make a copy of 
    * [Credentials](#Credentials)
 3. [Google Drive API](#Google-Drive-API)
    * [Authorizing requests to the Google Drive API](#Authorizing-requests-to-the-Google-Drive-API)
-   * [Signing into the application](#Signing-into-the-application)
+   * [Generate Google Drive access token](#Generate-Google-Drive-access-token)
    * [Enabling Google Drive API](#Enabling-Google-Drive-API)
    * [Template Post-mortem](#Template-Post-mortem)
 4. [Google Calendar API](#Google-Calendar-API)
    * [Authorizing requests to the Google Calendar API](#Authorizing-requests-to-the-Google-Calendar-API)
+   * [Generate Google Calendar access token](#Generate-Google-Calendar-access-token)
 5. [Setting environment variables](#Setting-environment-variables)
 
 
@@ -51,7 +52,7 @@ https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&respo
 4. Allow the permissions to your application to be able to access yours files.
 5. On this next page, take note of the **Code**. You'll need this going forward.
 
-### Signing into the application
+### Generate Google Drive access token
 1. Now you need to copy the **Client ID**, **Client Secret** and **Code** of the last steps (_[Credentials](#credentials) and [Authorizing requests to the Google Drive API](#Authorizing-requests-to-the-Google-Drive-API)_), and replace them respectively in the follow command:
 
 ```shell
@@ -113,6 +114,44 @@ https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&respo
 4. Allow the permissions to your application to be able to access yours files.
 5. On this next page, take note of the **Code**. You'll need this going forward.
 
+### Generate Google Calendar access token
+1. Now you need to copy the **Client ID**, **Client Secret** and **Code** of the last steps (_[Credentials](#credentials) and [Authorizing requests to the Google Calendar API](#Authorizing-requests-to-the-Google-Calendar-API))_), and replace them respectively in the follow command:
+
+```shell
+curl --data client_id="YOUR_CLIENT_ID_HERE" \
+  --data client_secret="YOUR_CLIENT_SECRET_HERE" \
+  --data code="YOUR_AUTH_CODE_HERE" \
+  --data redirect_uri=urn:ietf:wg:oauth:2.0:oob \
+  --data grant_type=authorization_code \
+  https://oauth2.googleapis.com/token
+```
+
+2. Run it in your terminal and copy the response.
+3. Past it in your environment variable called: `HELLPER_GOOGLE_CALENDAR_TOKEN`.
+
+
+#### Example
+**Run it in terminal**
+```shell
+curl --data client_id="YOUR_CLIENT_ID" \
+  --data client_secret="YOUR_CLIENT_SECRET" \
+  --data code="YOUR_AUTH_CODE" \
+  --data redirect_uri=urn:ietf:wg:oauth:2.0:oob \
+  --data grant_type=authorization_code \
+  https://oauth2.googleapis.com/token
+```
+
+**Response**
+```http
+{
+  "access_token": "xxxxxxxxxxxxxxxxxx",
+  "expires_in": 3599,
+  "refresh_token": "xxxxxxxxxxxxxxxxxx",
+  "scope": "https://www.googleapis.com/auth/calendar",
+  "token_type": "Bearer"
+}
+```
+
 
 ## Setting environment variables
 Now you need to change these three variables:
@@ -120,6 +159,6 @@ Now you need to change these three variables:
 | Variable | Explanation |
 | --- | --- |
 |**HELLPER_GOOGLE_CREDENTIALS** |[Google Credentials](/docs/CONFIGURING-GOOGLE.md#Get-a-Client-ID-and-Client-Secret)|
-|**HELLPER_GOOGLE_DRIVE_TOKEN**|[Google Drive Token](/docs/CONFIGURING-GOOGLE.md#Signing-into-the-application)|
+|**HELLPER_GOOGLE_DRIVE_TOKEN**|[Google Drive Token](/docs/CONFIGURING-GOOGLE.md#Generate-Google-Drive-access-tokenn)|
 |**HELLPER_GOOGLE_DRIVE_FILE_ID**|[Google Drive File Id](/docs/CONFIGURING-GOOGLE.md#Template-Post-mortem) to your post-mortem template|
 

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -36,7 +36,7 @@ The instructions here are a summary of the [official documentation](https://clou
 5. Copy the content file and paste it in your environment variable called: `HELLPER_GOOGLE_DRIVE_CREDENTIALS`.
 
 
-## Authorization code
+## Authorization requests to the Google Drive API
 1. Copy the **Client ID** you got in the last step (_[Credentials](#credentials)_).
 2. In the following URL, change `YOUR_CLIENT_ID_HERE` with the content from **Client ID**:
 

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -113,7 +113,7 @@ https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&respo
 ```
 
 3. Access the new URL in your web browser.
-4. Allow the permissions to your application to be able to access yours files.
+4. Allow the permissions to your application to be able to access your files.
 5. On this next page, take note of the **Code**. You'll need this going forward.
 
 ### Generate Google Calendar access token
@@ -181,4 +181,3 @@ Now you need to change these three variables:
 |**HELLPER_GOOGLE_DRIVE_FILE_ID**|[Google Drive File Id](/docs/CONFIGURING-GOOGLE.md#Template-Post-mortem) to your post-mortem template|
 |**HELLPER_GOOGLE_CALENDAR_TOKEN**|[Google Calendar Token](/docs/CONFIGURING-GOOGLE.md#Generate-Google-Calendar-access-token)|
 |**HELLPER_GOOGLE_CALENDAR_ID**|[Google Calendar Id](/docs/CONFIGURING-GOOGLE.md#Obtain-your-Google-Calendar's-ID) to schedule your post-mortem |
-

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -158,7 +158,7 @@ curl --data client_id="YOUR_CLIENT_ID" \
 Access [API Library](https://console.developers.google.com/apis/library/calendar-json.googleapis.com), then click **Enable**.
 
 ### Obtain your Google Calendar's ID
-If you don't need create a new google calendar go to step 6, otherwise follow the instructions bellow.
+If you don't need to create a new google calendar go to step 6, otherwise follow the instructions below.
 
 1. On your computer, open [Google Calendar](https://calendar.google.com)
 2. At the left, next to **Other calendars** click **Add other calendars** 

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -7,11 +7,14 @@ This instructions guide will give your application permission to make a copy of 
 2. [Get a Client ID and Client Secret](#Get-a-Client-ID-and-Client-Secret)
    * [OAuth consent screen](#OAuth-consent-screen)
    * [Credentials](#Credentials)
-3. [Authorization code](#Authorization-code)
-4. [Signing into the application](#Signing-into-the-application)
-5. [Enabling Google Drive API](#Enabling-Google-Drive-API)
-6. [Template Post-mortem](#Template-Post-mortem)
-7. [Setting environment variables](#Setting-environment-variables)
+3. [Google Drive API](#Google-Drive-API)
+   * [Authorizing requests to the Google Drive API](#Authorizing-requests-to-the-Google-Drive-API)
+   * [Signing into the application](#Signing-into-the-application)
+   * [Enabling Google Drive API](#Enabling-Google-Drive-API)
+   * [Template Post-mortem](#Template-Post-mortem)
+4. [Google Calendar API](#Google-Calendar-API)
+   * [Authorizing requests to the Google Calendar API](#Authorizing-requests-to-the-Google-Calendar-API)
+5. [Setting environment variables](#Setting-environment-variables)
 
 
 ## Official documentation
@@ -33,10 +36,10 @@ The instructions here are a summary of the [official documentation](https://clou
 2. Under **Application type**, choose **Other** and give it a name, _ie. Hellper_. Then, click **Create**.
 3. On this next page, take note of the **Client ID** and **Client Secret**. You'll need these going forward. Then, click **Ok**.
 4. At last, click in the Download icon button to configure your credentials.
-5. Copy the content file and paste it in your environment variable called: `HELLPER_GOOGLE_DRIVE_CREDENTIALS`.
+5. Copy the content file and paste it in your environment variable called: `HELLPER_GOOGLE_CREDENTIALS`.
 
-
-## Authorizing requests to the Google Drive API
+## Google Drive API
+### Authorizing requests to the Google Drive API
 1. Copy the **Client ID** you got in the last step (_[Credentials](#credentials)_).
 2. In the following URL, change `YOUR_CLIENT_ID_HERE` with the content from **Client ID**:
 
@@ -48,22 +51,8 @@ https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&respo
 4. Allow the permissions to your application to be able to access yours files.
 5. On this next page, take note of the **Code**. You'll need this going forward.
 
-
-## Authorizing requests to the Google Calendar API
-1. Copy the **Client ID** you got in the last step (_[Credentials](#credentials)_).
-2. In the following URL, change `YOUR_CLIENT_ID_HERE` with the content from **Client ID**:
-
-```
-https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&response_type=code&scope=https://www.googleapis.com/auth/calendar&access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob
-```
-
-3. Access the new URL in your web browser.
-4. Allow the permissions to your application to be able to access yours files.
-5. On this next page, take note of the **Code**. You'll need this going forward.
-
-
-## Signing into the application
-1. Now you need to copy the **Client ID**, **Client Secret** and **Code** of the last steps (_[Credentials](#credentials) and [Authorization Code](#authorization-code)_), and replace them respectively in the follow command:
+### Signing into the application
+1. Now you need to copy the **Client ID**, **Client Secret** and **Code** of the last steps (_[Credentials](#credentials) and [Authorizing requests to the Google Drive API](#Authorizing-requests-to-the-Google-Drive-API)_), and replace them respectively in the follow command:
 
 ```shell
 curl --data client_id="YOUR_CLIENT_ID_HERE" \
@@ -78,7 +67,7 @@ curl --data client_id="YOUR_CLIENT_ID_HERE" \
 3. Past it in your environment variable called: `HELLPER_GOOGLE_DRIVE_TOKEN`.
 
 
-### Example
+#### Example
 **Run it in terminal**
 ```shell
 curl --data client_id="YOUR_CLIENT_ID" \
@@ -100,17 +89,29 @@ curl --data client_id="YOUR_CLIENT_ID" \
 }
 ```
 
-
-## Enabling Google Drive API
+### Enabling Google Drive API
 Access [API Library](https://console.developers.google.com/apis/library/drive.googleapis.com), then click **Enable**.
 
 
-## Template Post-mortem
+### Template Post-mortem
 1. Create new a file in your Google Doc and copy the ID from the file, like this:
 
 `https://docs.google.com/document/d/YOUR_FILE_ID_IS_HERE/edit`
 
 2. Paste the ID in your environment variable called: `HELLPER_GOOGLE_DRIVE_FILE_ID`.
+
+## Google Calendar API
+### Authorizing requests to the Google Calendar API
+1. Copy the **Client ID** you got in the last step (_[Credentials](#credentials)_).
+2. In the following URL, change `YOUR_CLIENT_ID_HERE` with the content from **Client ID**:
+
+```
+https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&response_type=code&scope=https://www.googleapis.com/auth/calendar&access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob
+```
+
+3. Access the new URL in your web browser.
+4. Allow the permissions to your application to be able to access yours files.
+5. On this next page, take note of the **Code**. You'll need this going forward.
 
 
 ## Setting environment variables
@@ -118,6 +119,7 @@ Now you need to change these three variables:
 
 | Variable | Explanation |
 | --- | --- |
-|**HELLPER_GOOGLE_DRIVE_CREDENTIALS** |[Google Drive Credentials](/docs/CONFIGURING-GOOGLE.md#Get-a-Client-ID-and-Client-Secret)|
-|**HELLPER_GOOGLE_DRIVE_FILE_ID**|[Google Drive FileId](/docs/CONFIGURING-GOOGLE.md#Template-Post-mortem) to your post-mortem template|
-|**HELLPER_GOOGLE_DRIVE_TOKEN**|[Google Drive Token](/docs/CONFIGURING-GOOGLE.md#Signing-in-to-the-application)|
+|**HELLPER_GOOGLE_CREDENTIALS** |[Google Credentials](/docs/CONFIGURING-GOOGLE.md#Get-a-Client-ID-and-Client-Secret)|
+|**HELLPER_GOOGLE_DRIVE_TOKEN**|[Google Drive Token](/docs/CONFIGURING-GOOGLE.md#Signing-into-the-application)|
+|**HELLPER_GOOGLE_DRIVE_FILE_ID**|[Google Drive File Id](/docs/CONFIGURING-GOOGLE.md#Template-Post-mortem) to your post-mortem template|
+

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -16,6 +16,7 @@ This instructions guide will give your application permission to make a copy of 
    * [Authorizing requests to the Google Calendar API](#Authorizing-requests-to-the-Google-Calendar-API)
    * [Generate Google Calendar access token](#Generate-Google-Calendar-access-token)
    * [Enabling Google Calendar API](#Enabling-Google-Calendar-API)
+   * [Obtain your Google Calendar's ID](#Obtain-your-Google-Calendar's-ID)
 5. [Setting environment variables](#Setting-environment-variables)
 
 
@@ -155,6 +156,20 @@ curl --data client_id="YOUR_CLIENT_ID" \
 
 ### Enabling Google Calendar API
 Access [API Library](https://console.developers.google.com/apis/library/calendar-json.googleapis.com), then click **Enable**.
+
+### Obtain your Google Calendar's ID
+If you don't need create a new google calendar go to step 6, otherwise follow the instructions bellow.
+
+1. On your computer, open [Google Calendar](https://calendar.google.com)
+2. At the left, next to **Other calendars** click **Add other calendars** 
+3. Click **Create new calendar**
+4. Add a name and description for your calendar
+5. Click **Create calendar**
+6. In the Google Calendar interface, locate the **My calendars** area on the left
+7. Hover over the calendar you need and click the downward arrow
+8. A menu will appear. Click **Calendar settings**
+9. In the **Calendar Address** section of the screen, you will see your **Calendar ID**. It will look something like: `abcd1234@group.calendar.google.com`
+10. Paste the ID in your environment variable called: `HELLPER_GOOGLE_CALENDAR_ID`
 
 ## Setting environment variables
 Now you need to change these three variables:

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -49,6 +49,19 @@ https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&respo
 5. On this next page, take note of the **Code**. You'll need this going forward.
 
 
+## Authorizing requests to the Google Calendar API
+1. Copy the **Client ID** you got in the last step (_[Credentials](#credentials)_).
+2. In the following URL, change `YOUR_CLIENT_ID_HERE` with the content from **Client ID**:
+
+```
+https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&response_type=code&scope=https://www.googleapis.com/auth/drive&access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob
+```
+
+3. Access the new URL in your web browser.
+4. Allow the permissions to your application to be able to access yours files.
+5. On this next page, take note of the **Code**. You'll need this going forward.
+
+
 ## Signing into the application
 1. Now you need to copy the **Client ID**, **Client Secret** and **Code** of the last steps (_[Credentials](#credentials) and [Authorization Code](#authorization-code)_), and replace them respectively in the follow command:
 

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -54,7 +54,7 @@ https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&respo
 2. In the following URL, change `YOUR_CLIENT_ID_HERE` with the content from **Client ID**:
 
 ```
-https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&response_type=code&scope=https://www.googleapis.com/auth/drive&access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob
+https://accounts.google.com/o/oauth2/v2/auth?client_id=YOUR_CLIENT_ID_HERE&response_type=code&scope=https://www.googleapis.com/auth/calendar&access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob
 ```
 
 3. Access the new URL in your web browser.

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -15,6 +15,7 @@ This instructions guide will give your application permission to make a copy of 
 4. [Google Calendar API](#Google-Calendar-API)
    * [Authorizing requests to the Google Calendar API](#Authorizing-requests-to-the-Google-Calendar-API)
    * [Generate Google Calendar access token](#Generate-Google-Calendar-access-token)
+   * [Enabling Google Calendar API](#Enabling-Google-Calendar-API)
 5. [Setting environment variables](#Setting-environment-variables)
 
 
@@ -152,6 +153,8 @@ curl --data client_id="YOUR_CLIENT_ID" \
 }
 ```
 
+### Enabling Google Calendar API
+Access [API Library](https://console.developers.google.com/apis/library/calendar-json.googleapis.com), then click **Enable**.
 
 ## Setting environment variables
 Now you need to change these three variables:

--- a/docs/CONFIGURING-GOOGLE.md
+++ b/docs/CONFIGURING-GOOGLE.md
@@ -177,6 +177,9 @@ Now you need to change these three variables:
 | Variable | Explanation |
 | --- | --- |
 |**HELLPER_GOOGLE_CREDENTIALS** |[Google Credentials](/docs/CONFIGURING-GOOGLE.md#Get-a-Client-ID-and-Client-Secret)|
-|**HELLPER_GOOGLE_DRIVE_TOKEN**|[Google Drive Token](/docs/CONFIGURING-GOOGLE.md#Generate-Google-Drive-access-tokenn)|
+|**HELLPER_GOOGLE_DRIVE_TOKEN**|[Google Drive Token](/docs/CONFIGURING-GOOGLE.md#Generate-Google-Drive-access-token)|
 |**HELLPER_GOOGLE_DRIVE_FILE_ID**|[Google Drive File Id](/docs/CONFIGURING-GOOGLE.md#Template-Post-mortem) to your post-mortem template|
+|**HELLPER_GOOGLE_CALENDAR_TOKEN**|[Google Calendar Token](/docs/CONFIGURING-GOOGLE.md#Generate-Google-Calendar-access-token)|
+|**HELLPER_GOOGLE_CALENDAR_ID**|[Google Calendar Id](/docs/CONFIGURING-GOOGLE.md#Obtain-your-Google-Calendar's-ID) to schedule your post-mortem |
+
 


### PR DESCRIPTION
### Description
This PR create a section about how authorizing Requests to the Google Calendar API, adding this steps inside _CONFIGURING-GOOGLE.md_:
1. Authorizing requests to the Google Calendar API
2. Generate Google Calendar access token
3. Enabling Google Calendar API
4. Obtain your Google Calendar's ID

### How to test?
Follow all steps in the Google Calendar API section

### Expected behavior
After completing the instructions, you need to have the values of this enviroment variables 
 * [ ] _HELLPER_GOOGLE_CALENDAR_TOKEN_ 
 * [ ] _HELLPER_GOOGLE_CALENDAR_ID_ 
