### PR TITLE
Insert the incident's commander email on database

### DIFF
--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -184,7 +184,7 @@ func StartIncidentByDialog(
 		IdentificationTimestamp: &now,
 		SeverityLevel:           severityLevelInt64,
 		IncidentAuthor:          incidentAuthor,
-		Commander:               commander,
+		CommanderId:             commander,
 	}
 
 	incidentID, err := repository.InsertIncident(ctx, &incident)
@@ -274,7 +274,7 @@ func createOpenAttachment(incident model.Incident, incidentID int64, warRoomURL 
 	messageText.WriteString("*Severity:* " + getSeverityLevelText(incident.SeverityLevel) + "\n\n")
 	messageText.WriteString("*Product:* " + incident.Product + "\n")
 	messageText.WriteString("*Channel:* <#" + incident.ChannelId + ">\n")
-	messageText.WriteString("*Commander:* <@" + incident.Commander + ">\n\n")
+	messageText.WriteString("*Commander:* <@" + incident.CommanderId + ">\n\n")
 	messageText.WriteString("*Description:* `" + incident.DescriptionStarted + "`\n\n")
 	messageText.WriteString("*War Room:* " + warRoomURL + "\n")
 	messageText.WriteString("*cc:* <@" + supportTeam + ">\n")
@@ -299,7 +299,7 @@ func createOpenAttachment(incident model.Incident, incidentID int64, warRoomURL 
 			},
 			{
 				Title: "Commander",
-				Value: "<@" + incident.Commander + ">",
+				Value: "<@" + incident.CommanderId + ">",
 			},
 			{
 				Title: "Description",

--- a/internal/model/incident.go
+++ b/internal/model/incident.go
@@ -32,5 +32,6 @@ type Incident struct {
 	DescriptionResolved     string     `db:"description_resolved,omitempty"`
 	ChannelId               string     `db:"channel_id,omitempty"`
 	IncidentAuthor          string     `db:"incident_author_id,omitempty"`
-	Commander               string     `db:"commander,omitempty"`
+	CommanderId             string     `db:"commander_id,omitempty"`
+	CommanderEmail          string     `db:"commander_email,omitempty"`
 }

--- a/internal/model/sql/postgres/repository.go
+++ b/internal/model/sql/postgres/repository.go
@@ -45,7 +45,8 @@ func incidentLogValues(inc *model.Incident) []log.Value {
 		log.NewValue("severityLevel", inc.SeverityLevel),
 		log.NewValue("channelName", inc.ChannelName),
 		log.NewValue("channelID", inc.ChannelId),
-		log.NewValue("commander", inc.Commander),
+		log.NewValue("commanderID", inc.CommanderId),
+		log.NewValue("commanderEmail", inc.CommanderEmail),
 	}
 }
 
@@ -75,8 +76,9 @@ func (r *repository) InsertIncident(ctx context.Context, inc *model.Incident) (i
 		, severity_level
 		, channel_name
 		, channel_id
-		, commander)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+		, commander_id
+		, commander_email)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
 	RETURNING id`
 
 	id := int64(0)
@@ -101,7 +103,8 @@ func (r *repository) InsertIncident(ctx context.Context, inc *model.Incident) (i
 		inc.SeverityLevel,
 		inc.ChannelName,
 		inc.ChannelId,
-		inc.Commander)
+		inc.CommanderId,
+		inc.CommanderEmail)
 
 	switch err := idResult.Scan(&id); err {
 	case nil:
@@ -214,7 +217,8 @@ func (r *repository) GetIncident(ctx context.Context, channelID string) (inc mod
 		&inc.SeverityLevel,
 		&inc.ChannelName,
 		&inc.ChannelId,
-		&inc.Commander,
+		&inc.CommanderId,
+		&inc.CommanderEmail,
 	)
 
 	r.logger.Info(
@@ -246,7 +250,8 @@ func GetIncidentByChannelID() string {
 		, CASE WHEN severity_level IS NULL THEN 0 ELSE severity_level END AS severity_level
 		, CASE WHEN channel_name IS NULL THEN '' ELSE channel_name END AS channel_name
 		, CASE WHEN channel_id IS NULL THEN '' ELSE channel_id END AS channel_id
-		, CASE WHEN commander IS NULL THEN '' ELSE commander END commander
+		, CASE WHEN commander_id IS NULL THEN '' ELSE commander_id END commander_id
+		, CASE WHEN commander_email IS NULL THEN '' ELSE commander_email END commander_email
 	FROM incident
 	WHERE channel_id = $1
 	LIMIT 1`
@@ -574,7 +579,8 @@ func (r *repository) ListActiveIncidents(ctx context.Context) ([]model.Incident,
 			&inc.SeverityLevel,
 			&inc.ChannelName,
 			&inc.ChannelId,
-			&inc.Commander,
+			&inc.CommanderId,
+			&inc.CommanderEmail,
 		)
 		if err != nil {
 			r.logger.Error(
@@ -619,7 +625,8 @@ func GetIncidentStatusFilterQuery() string {
 		, CASE WHEN severity_level IS NULL THEN 0 ELSE severity_level END AS severity_level
 		, CASE WHEN channel_name IS NULL THEN '' ELSE channel_name END AS channel_name
 		, CASE WHEN channel_id IS NULL THEN '' ELSE channel_id END AS channel_id
-		, CASE WHEN commander IS NULL THEN '' ELSE commander END commander
+		, CASE WHEN commander_id IS NULL THEN '' ELSE commander_id END commander_id
+		, CASE WHEN commander_email IS NULL THEN '' ELSE commander_email END commander_email
 	FROM incident
 	WHERE status IN ($1)
 	LIMIT 10`

--- a/internal/model/sql/postgres/schema/hellper.sql
+++ b/internal/model/sql/postgres/schema/hellper.sql
@@ -23,7 +23,8 @@ CREATE TABLE public.incident (
 	description_cancelled text NULL,
 	description_resolved text NULL,
 	channel_id varchar(50) NULL,
-  commander text NULL,
+  commander_id text NULL,
+  commander_email text NULL,
 	CONSTRAINT firstkey PRIMARY KEY (id)
 );
 
@@ -48,7 +49,8 @@ CREATE OR REPLACE VIEW public.metrics
     incident.description_cancelled,
     incident.description_resolved,
     incident.end_ts::date AS date,
-    incident.commander,
+    incident.commander_id,
+    incident.commander_email,
     to_char(incident.start_ts, 'YYYY-MM-DD HH24:MI:SS'::text) AS start_ts,
     to_char(incident.end_ts, 'YYYY-MM-DD HH24:MI:SS'::text) AS end_ts,
     to_char(incident.identification_ts, 'YYYY-MM-DD HH24:MI:SS'::text) AS identification_ts,


### PR DESCRIPTION
### Description
This PR create a new column named commander in to hellper's database and add this column on database's controller.

### How to test?
On a local or staging environment, open an incident and verify if commander's column  is created with a value.

If you are going to  using the local environment for this test, first run this code on the   local database:


```

ALTER TABLE incident 
RENAME COLUMN commander TO commander_id;

```

```
ALTER TABLE incident
  ADD commander_email text NULL;

```

```
DROP VIEW public.metrics;

CREATE OR REPLACE VIEW public.metrics
  AS SELECT
    incident.id,
    incident.title,
    incident.channel_id,
    incident.product,
    incident.team,
    incident.responsibility,
    incident.functionality,
    incident.root_cause,
    incident.severity_level,
    incident.status_page_url,
    incident.post_mortem_url,
    incident.channel_name,
    incident.status,
    incident.description_started,
    incident.description_cancelled,
    incident.description_resolved,
    incident.end_ts::date AS date,
    incident.commander_id,
    incident.commander_email,
    to_char(incident.start_ts, 'YYYY-MM-DD HH24:MI:SS'::text) AS start_ts,
    to_char(incident.end_ts, 'YYYY-MM-DD HH24:MI:SS'::text) AS end_ts,
    to_char(incident.identification_ts, 'YYYY-MM-DD HH24:MI:SS'::text) AS identification_ts,
    to_char(incident.updated_at, 'YYYY-MM-DD HH24:MI:SS'::text) AS updated_at,
    COALESCE(incident.customer_impact, 0) AS customer_impact,
    COALESCE(date_part('epoch'::text, incident.identification_ts - incident.start_ts), 0::double precision) AS acknowledgetime,
    COALESCE(date_part('epoch'::text, incident.end_ts - incident.identification_ts), 0::double precision) AS solutiontime,
    COALESCE(date_part('epoch'::text, incident.end_ts - incident.start_ts), 0::double precision) AS downtime
   FROM incident
  WHERE incident.start_ts IS NOT NULL AND incident.end_ts IS NOT NULL AND incident.identification_ts IS NOT NULL AND incident.end_ts::date >= '2020-01-01'::date
  ORDER BY (incident.end_ts::date);

-- Permissions
ALTER TABLE public.metrics OWNER TO hellper;
GRANT ALL ON TABLE public.metrics TO hellper;
```

### Expected behavior
Hellper must be able to create the incident  without a problem and atribute a value to the commander's column