### PR TITLE
Create user.go in the command package

### DIFF
--- a/internal/bot/client.go
+++ b/internal/bot/client.go
@@ -12,7 +12,7 @@ type Client interface {
 	CreateChannel(string) (*slack.Channel, error)
 	InviteUserToChannel(string, string) (*slack.Channel, error)
 	ListPins(string) ([]slack.Item, *slack.Paging, error)
-	GetUserInfo(string) (*slack.User, error)
+	GetUserInfoContext(context.Context, string) (*slack.User, error)
 	SetChannelTopic(string, string) (string, error)
 	OpenDialog(string, slack.Dialog) error
 	AddPin(string, slack.ItemRef) error

--- a/internal/bot/client_mock.go
+++ b/internal/bot/client_mock.go
@@ -61,9 +61,9 @@ func (mock *ClientMock) ListPins(channelID string) ([]slack.Item, *slack.Paging,
 	return items, paging, args.Error(2)
 }
 
-func (mock *ClientMock) GetUserInfo(userID string) (*slack.User, error) {
+func (mock *ClientMock) GetUserInfoContext(ctx context.Context, userID string) (*slack.User, error) {
 	var (
-		args   = mock.Called(userID)
+		args   = mock.Called(ctx, userID)
 		result = args.Get(0)
 	)
 	if result == nil {

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -147,16 +147,15 @@ func StartIncidentByDialog(
 	)
 
 	var (
-		now            = time.Now().UTC()
-		incidentAuthor = incidentDetails.User.ID
-		submission     = incidentDetails.Submission
-		channelName    = submission.ChannelName
-		warRoomURL     = submission.WarRoomURL
-		severityLevel  = submission.SeverityLevel
-		product        = submission.Product
-		commander      = submission.IncidentCommander
-		description    = submission.IncidentDescription
-		
+		now              = time.Now().UTC()
+		incidentAuthor   = incidentDetails.User.ID
+		submission       = incidentDetails.Submission
+		channelName      = submission.ChannelName
+		warRoomURL       = submission.WarRoomURL
+		severityLevel    = submission.SeverityLevel
+		product          = submission.Product
+		commander        = submission.IncidentCommander
+		description      = submission.IncidentDescription
 		environment      = config.Env.Environment
 		matrixURL        = config.Env.MatrixHost
 		supportTeam      = config.Env.SupportTeam
@@ -164,7 +163,7 @@ func StartIncidentByDialog(
 		stagingRoom      = "dc82e346-639c-44ee-a470-63f7545ae8e4"
 	)
 
-	user, err := getSlackUserInfo(ctx,client,logger,commander)
+	user, err := getSlackUserInfo(ctx, client, logger, commander)
 	if err != nil {
 		return fmt.Errorf("commands.StartIncidentByDialog.get_slack_user_info: incident=%v commanderId=%v error=%v", channelName, commander, err)
 	}
@@ -189,8 +188,8 @@ func StartIncidentByDialog(
 		IdentificationTimestamp: &now,
 		SeverityLevel:           severityLevelInt64,
 		IncidentAuthor:          incidentAuthor,
-		CommanderId:             user.SlackId,
-		CommanderEmail:			 user.Email,
+		CommanderId:             user.SlackID,
+		CommanderEmail:          user.Email,
 	}
 
 	incidentID, err := repository.InsertIncident(ctx, &incident)

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -156,13 +156,18 @@ func StartIncidentByDialog(
 		product        = submission.Product
 		commander      = submission.IncidentCommander
 		description    = submission.IncidentDescription
-
+		
 		environment      = config.Env.Environment
 		matrixURL        = config.Env.MatrixHost
 		supportTeam      = config.Env.SupportTeam
 		productChannelID = config.Env.ProductChannelID
 		stagingRoom      = "dc82e346-639c-44ee-a470-63f7545ae8e4"
 	)
+
+	user, err := getSlackUserInfo(ctx,client,logger,commander)
+	if err != nil {
+		return fmt.Errorf("commands.StartIncidentByDialog.get_slack_user_info: incident=%v commanderId=%v error=%v", channelName, commander, err)
+	}
 
 	channel, err := client.CreateChannel(channelName)
 	if err != nil {
@@ -184,7 +189,8 @@ func StartIncidentByDialog(
 		IdentificationTimestamp: &now,
 		SeverityLevel:           severityLevelInt64,
 		IncidentAuthor:          incidentAuthor,
-		CommanderId:             commander,
+		CommanderId:             user.SlackId,
+		CommanderEmail:			 user.Email,
 	}
 
 	incidentID, err := repository.InsertIncident(ctx, &incident)

--- a/internal/commands/show_status.go
+++ b/internal/commands/show_status.go
@@ -116,11 +116,11 @@ func createStatusAttachment(ctx context.Context, client bot.Client, logger log.L
 			}
 
 			if item.Message.User != "" {
-				user, err := client.GetUserInfo(item.Message.User)
+				user, err := client.GetUserInfoContext(ctx, item.Message.User)
 				if err != nil {
 					logger.Error(
 						ctx,
-						"command/show_status.createStatusAttachment GetUserInfo error",
+						"command/show_status.createStatusAttachment GetUserInfoContext error",
 						log.NewValue("channelID", channelID),
 						log.NewValue("error", err),
 					)

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -1,5 +1,5 @@
 package commands
- 
+
 import (
 	"context"
 
@@ -8,19 +8,18 @@ import (
 	"hellper/internal/model"
 )
 
-
 func getSlackUserInfo(
 	ctx context.Context,
 	client bot.Client,
 	logger log.Logger,
 	userID string,
-)(*model.User, error) {
+) (*model.User, error) {
 
-	slackUser, err := client.GetUserInfo(userID)
+	slackUser, err := client.GetUserInfoContext(ctx, userID)
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/user.getUserInfo error",
+			"command/user.getSlackUserInfo error",
 			log.NewValue("userID", userID),
 			log.NewValue("error", err),
 		)
@@ -28,10 +27,10 @@ func getSlackUserInfo(
 		return nil, err
 	}
 
-	user := model.User {
-		SlackId:	slackUser.ID,
-		Name:		slackUser.Profile.RealName,
-		Email:		slackUser.Profile.Email,	
+	user := model.User{
+		SlackId: slackUser.ID,
+		Name:    slackUser.Profile.RealName,
+		Email:   slackUser.Profile.Email,
 	}
 
 	return &user, err

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -28,7 +28,7 @@ func getSlackUserInfo(
 	}
 
 	user := model.User{
-		SlackId: slackUser.ID,
+		SlackID: slackUser.ID,
 		Name:    slackUser.Profile.RealName,
 		Email:   slackUser.Profile.Email,
 	}

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -1,0 +1,38 @@
+package commands
+ 
+import (
+	"context"
+
+	"hellper/internal/bot"
+	"hellper/internal/log"
+	"hellper/internal/model"
+)
+
+
+func getSlackUserInfo(
+	ctx context.Context,
+	client bot.Client,
+	logger log.Logger,
+	userID string,
+)(*model.User, error) {
+
+	slackUser, err := client.GetUserInfo(userID)
+	if err != nil {
+		logger.Error(
+			ctx,
+			"command/user.getUserInfo error",
+			log.NewValue("userID", userID),
+			log.NewValue("error", err),
+		)
+
+		return nil, err
+	}
+
+	user := model.User {
+		SlackId:	slackUser.ID,
+		Name:		slackUser.Profile.RealName,
+		Email:		slackUser.Profile.Email,	
+	}
+
+	return &user, err
+}

--- a/internal/commands/user_test.go
+++ b/internal/commands/user_test.go
@@ -1,0 +1,109 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"hellper/internal/bot"
+	"hellper/internal/log"
+	"hellper/internal/model"
+
+	"github.com/slack-go/slack"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"context"
+	"testing"
+)
+
+type userCommandFixture struct {
+	testName                string
+	expectError             bool
+	errorMessage            string
+	getUserInfoContextError error
+	mockUser                *model.User
+	mockSlackUser           *slack.User
+
+	ctx        context.Context
+	mockLogger log.Logger
+	mockClient bot.Client
+
+	userID string
+}
+
+func (f *userCommandFixture) setup(t *testing.T) {
+	var (
+		loggerMock = log.NewLoggerMock()
+		clientMock = bot.NewClientMock()
+	)
+
+	f.ctx = context.Background()
+
+	loggerMock.On("Info", f.ctx, mock.AnythingOfType("string"), mock.AnythingOfType("[]log.Value")).Return()
+	loggerMock.On("Error", f.ctx, mock.AnythingOfType("string"), mock.AnythingOfType("[]log.Value")).Return()
+	clientMock.On("GetUserInfoContext", f.ctx, mock.AnythingOfType("string")).Return(f.mockSlackUser, f.getUserInfoContextError)
+
+	f.mockLogger = loggerMock
+	f.mockClient = clientMock
+}
+
+func TestGetSlackUserInfo(t *testing.T) {
+	users := []userCommandFixture{
+		{
+			testName:      "Get slack user info with valid slack user Id",
+			expectError:   false,
+			userID:        "U013NAYQ1PG",
+			mockUser:      buildUserMock(),
+			mockSlackUser: buildSlackMock(),
+		},
+		{
+			testName:                "User not found",
+			expectError:             true,
+			userID:                  "xunda",
+			errorMessage:            "User not found",
+			getUserInfoContextError: errors.New("User not found"),
+		},
+	}
+
+	for index, f := range users {
+		t.Run(fmt.Sprintf("%v-%v", index, f.testName), func(t *testing.T) {
+			f.setup(t)
+
+			user, err := getSlackUserInfo(f.ctx, f.mockClient, f.mockLogger, f.userID)
+
+			if f.expectError {
+				if err == nil {
+					t.Fatal("an error was expected, but not occurred")
+				}
+				assert.EqualError(t, err, f.errorMessage)
+			}
+
+			if !f.expectError {
+				if err != nil {
+					t.Fatal("an error occurred, but was not expected")
+				}
+				assert.Equal(t, f.mockUser, user)
+			}
+		})
+	}
+}
+
+func buildUserMock() *model.User {
+
+	return &model.User{
+		Id:      0,
+		SlackId: "U013NAYQ1PG",
+		Name:    "Natalia Favareto",
+		Email:   "natalia.favareto@resultadosdigitais.com.br",
+	}
+}
+
+func buildSlackMock() *slack.User {
+
+	return &slack.User{
+		ID: "U013NAYQ1PG",
+		Profile: slack.UserProfile{
+			RealName: "Natalia Favareto",
+			Email:    "natalia.favareto@resultadosdigitais.com.br",
+		},
+	}
+}

--- a/internal/commands/user_test.go
+++ b/internal/commands/user_test.go
@@ -91,7 +91,7 @@ func buildUserMock() *model.User {
 
 	return &model.User{
 		Id:      0,
-		SlackId: "U013NAYQ1PG",
+		SlackID: "U013NAYQ1PG",
 		Name:    "Natalia Favareto",
 		Email:   "natalia.favareto@resultadosdigitais.com.br",
 	}

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -1,10 +1,8 @@
 package model
 
-
-
 type User struct {
-	Id			int64       
-	SlackId		string       
-	Name		string
-	Email		string
+	Id      int64
+	SlackID string
+	Name    string
+	Email   string
 }

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -1,0 +1,10 @@
+package model
+
+
+
+type User struct {
+	Id			int64       
+	SlackId		string       
+	Name		string
+	Email		string
+}


### PR DESCRIPTION
### Description
This PR creates a user.go in the command package. This new file has a function for obtaining loose user information using the user ID.

At the moment, user.go is tightly attached to the slack, as the command package is like that..

### How to test?
On a local or staging environment, open an incident and verify if commander's columns  is created with a value.

- commander_id
- commander_email

### Expected behavior
Hellper must be able to create the incident  without a problem and atribute a value to the commander's columns