### PR TITLE
Initialize calendar package

### DIFF
--- a/internal/calendar/google_calendar/calendar.go
+++ b/internal/calendar/google_calendar/calendar.go
@@ -3,7 +3,6 @@ package googlecalendar
 import (
 	"context"
 	"hellper/internal/calendar"
-	"hellper/internal/config"
 	googleauth "hellper/internal/google_auth"
 	"hellper/internal/log"
 
@@ -16,8 +15,8 @@ type googleCalendar struct {
 }
 
 //NewCalendar initialize the file storage service
-func NewCalendar(ctx context.Context, logger log.Logger) calendar.Calendar {
-	calendarTokenBytes := []byte(config.Env.GoogleCalendarToken)
+func NewCalendar(ctx context.Context, logger log.Logger, calendarToken string) (calendar.Calendar, error) {
+	calendarTokenBytes := []byte(calendarToken)
 
 	gClient, err := googleauth.Struct.GetGClient(ctx, logger, calendarTokenBytes, gCalendar.CalendarScope)
 	if err != nil {
@@ -27,7 +26,7 @@ func NewCalendar(ctx context.Context, logger log.Logger) calendar.Calendar {
 			log.NewValue("error", err),
 		)
 
-		return nil
+		return nil, err
 	}
 
 	calendarService, err := gCalendar.New(gClient)
@@ -38,13 +37,15 @@ func NewCalendar(ctx context.Context, logger log.Logger) calendar.Calendar {
 			log.NewValue("error", err),
 		)
 
-		return nil
+		return nil, err
 	}
 
-	return &googleCalendar{
+	calendar := googleCalendar{
 		logger:          logger,
 		calendarService: calendarService,
 	}
+
+	return &calendar, nil
 }
 
 //CreateCalendarEvent creates a event in Google Calendar

--- a/internal/calendar/google_calendar/calendar.go
+++ b/internal/calendar/google_calendar/calendar.go
@@ -1,12 +1,50 @@
 package googlecalendar
 
-import "hellper/internal/calendar"
+import (
+	"context"
+	"hellper/internal/calendar"
+	"hellper/internal/config"
+	googleauth "hellper/internal/google_auth"
+	"hellper/internal/log"
 
-type googleCalendar struct{}
+	gCalendar "google.golang.org/api/calendar/v3"
+)
+
+type googleCalendar struct {
+	logger          log.Logger
+	calendarService *gCalendar.Service
+}
 
 //NewCalendar initialize the file storage service
-func NewCalendar() calendar.Calendar {
-	return new(googleCalendar)
+func NewCalendar(ctx context.Context, logger log.Logger) calendar.Calendar {
+	calendarTokenBytes := []byte(config.Env.GoogleCalendarToken)
+
+	gClient, err := googleauth.Struct.GetGClient(ctx, logger, calendarTokenBytes, gCalendar.CalendarScope)
+	if err != nil {
+		logger.Error(
+			ctx,
+			"googlecalendar/calendar.NewCalendar GetGClient ERROR",
+			log.NewValue("error", err),
+		)
+
+		return nil
+	}
+
+	calendarService, err := gCalendar.New(gClient)
+	if err != nil {
+		logger.Error(
+			ctx,
+			"googlecalendar/calendar.NewCalendar gCalendar.New ERROR",
+			log.NewValue("error", err),
+		)
+
+		return nil
+	}
+
+	return &googleCalendar{
+		logger:          logger,
+		calendarService: calendarService,
+	}
 }
 
 //CreateCalendarEvent creates a event in Google Calendar

--- a/internal/calendar/google_calendar/calendar_test.go
+++ b/internal/calendar/google_calendar/calendar_test.go
@@ -1,10 +1,14 @@
 package googlecalendar
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"hellper/internal/log"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type googleCalendarFixture struct {
@@ -13,10 +17,17 @@ type googleCalendarFixture struct {
 	errorMessage string
 
 	calendarService googleCalendar
+
+	ctx        context.Context
+	mockLogger log.Logger
 }
 
 func (f *googleCalendarFixture) setup(t *testing.T) {
+	f.ctx = context.Background()
 
+	loggerMock := log.NewLoggerMock()
+	loggerMock.On("Error", f.ctx, mock.AnythingOfType("string"), mock.AnythingOfType("[]log.Value")).Return()
+	f.mockLogger = loggerMock
 }
 
 func TestCreateCalendarEvent(t *testing.T) {

--- a/internal/google_auth/auth_mock.go
+++ b/internal/google_auth/auth_mock.go
@@ -1,0 +1,30 @@
+package googleauth
+
+import (
+	"context"
+	"hellper/internal/log"
+	"net/http"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type AuthMock struct {
+	mock.Mock
+}
+
+func NewAuthMock() *AuthMock {
+	return new(AuthMock)
+}
+
+func (mock *AuthMock) GetGClient(ctx context.Context, logger log.Logger, token []byte, scope string) (*http.Client, error) {
+	var (
+		args   = mock.Called(ctx, logger, token, scope)
+		result = args.Get(0)
+	)
+
+	if result == nil {
+		return nil, args.Error(1)
+	}
+
+	return result.(*http.Client), args.Error(1)
+}

--- a/internal/handler/route.go
+++ b/internal/handler/route.go
@@ -22,7 +22,7 @@ var (
 )
 
 func init() {
-	logger, client, repository, fileStorage := internal.New()
+	logger, client, repository, fileStorage, _ := internal.New()
 	openHandler = newHandlerOpen(logger, client, repository)
 	eventsHandler = newHandlerEvents(logger, client, repository)
 	interactiveHandler = newHandlerInteractive(logger, client, repository, fileStorage)


### PR DESCRIPTION
### Description
Creates a function that initializes the calendar package. This initialization creates a Google Calendar Service and a logger.

### How to test?
When the environment starts, the service must be initialized too, without any error. But this package has no use yet.

### Expected behavior
Everything should work fine, and should not be any error log related to the calendar package.