### PR TITLE
Hydra insert calendar event

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /app/hellper /app/cmd/http
 
 FROM debian:buster
-RUN apt update && apt upgrade && apt install ca-certificates -y
+RUN apt update -y && apt upgrade -y && apt install ca-certificates -y
 COPY --from=builder /app/hellper /app/hellper
 EXPOSE 8080
 

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,6 @@ google.golang.org/api v0.15.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsb
 google.golang.org/api v0.17.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.18.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
-google.golang.org/api v0.24.0 h1:cG03eaksBzhfSIk7JRGctfp3lanklcOM/mTGvow7BbQ=
-google.golang.org/api v0.24.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.25.0 h1:LodzhlzZEUfhXzNUMIfVlf9Gr6Ua5MMtoFWh7+f47qA=
 google.golang.org/api v0.25.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/internal/calendar/google_calendar/calendar.go
+++ b/internal/calendar/google_calendar/calendar.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"hellper/internal/calendar"
 	"hellper/internal/config"
+	"hellper/internal/google"
 	googleauth "hellper/internal/google_auth"
 	"hellper/internal/log"
 
@@ -12,8 +13,8 @@ import (
 
 type googleCalendar struct {
 	logger          log.Logger
-	calendarService *gCalendar.Service
-	eventsService   *gCalendar.EventsService
+	calendarService google.CalendarService
+	eventsService   google.CalendarEventsService
 }
 
 //NewCalendar initialize the calendar service
@@ -31,7 +32,7 @@ func NewCalendar(ctx context.Context, logger log.Logger, calendarToken string) (
 		return nil, err
 	}
 
-	calendarService, err := gCalendar.New(gClient)
+	calendarService, err := google.NewCalendarService(gClient)
 	if err != nil {
 		logger.Error(
 			ctx,
@@ -42,7 +43,8 @@ func NewCalendar(ctx context.Context, logger log.Logger, calendarToken string) (
 		return nil, err
 	}
 
-	eventsService := gCalendar.NewEventsService(calendarService)
+	s := calendarService.(gCalendar.Service)
+	eventsService := google.NewCalendarEventsService(&s)
 
 	calendar := googleCalendar{
 		logger:          logger,

--- a/internal/calendar/google_calendar/calendar.go
+++ b/internal/calendar/google_calendar/calendar.go
@@ -3,7 +3,6 @@ package googlecalendar
 import (
 	"context"
 	"hellper/internal/calendar"
-	"hellper/internal/config"
 	"hellper/internal/google"
 	googleauth "hellper/internal/google_auth"
 	"hellper/internal/log"
@@ -15,10 +14,16 @@ type googleCalendar struct {
 	logger          log.Logger
 	calendarService google.CalendarService
 	eventsService   google.CalendarEventsService
+	calendarID      string
 }
 
 //NewCalendar initialize the calendar service
-func NewCalendar(ctx context.Context, logger log.Logger, calendarToken string) (calendar.Calendar, error) {
+func NewCalendar(
+	ctx context.Context,
+	logger log.Logger,
+	calendarToken string,
+	calendarID string,
+) (calendar.Calendar, error) {
 	calendarTokenBytes := []byte(calendarToken)
 
 	gClient, err := googleauth.Struct.GetGClient(ctx, logger, calendarTokenBytes, gCalendar.CalendarScope)
@@ -50,6 +55,7 @@ func NewCalendar(ctx context.Context, logger log.Logger, calendarToken string) (
 		logger:          logger,
 		calendarService: calendarService,
 		eventsService:   eventsService,
+		calendarID:      calendarID,
 	}
 
 	return &calendar, nil
@@ -88,12 +94,8 @@ func event(start, end, summary string, emails []string, commander string) *gCale
 	}
 }
 
-func calendarID() string {
-	return config.Env.GoogleCalendarID
-}
-
 func (gc *googleCalendar) insertEnvent(event *gCalendar.Event) *gCalendar.EventsInsertCall {
-	return gc.eventsService.Insert(calendarID(), event)
+	return gc.eventsService.Insert(gc.calendarID, event)
 }
 
 //CreateCalendarEvent creates a event in Google Calendar

--- a/internal/calendar/google_calendar/calendar.go
+++ b/internal/calendar/google_calendar/calendar.go
@@ -13,9 +13,10 @@ import (
 type googleCalendar struct {
 	logger          log.Logger
 	calendarService *gCalendar.Service
+	eventsService   *gCalendar.EventsService
 }
 
-//NewCalendar initialize the file storage service
+//NewCalendar initialize the calendar service
 func NewCalendar(ctx context.Context, logger log.Logger, calendarToken string) (calendar.Calendar, error) {
 	calendarTokenBytes := []byte(calendarToken)
 
@@ -41,9 +42,12 @@ func NewCalendar(ctx context.Context, logger log.Logger, calendarToken string) (
 		return nil, err
 	}
 
+	eventsService := gCalendar.NewEventsService(calendarService)
+
 	calendar := googleCalendar{
 		logger:          logger,
 		calendarService: calendarService,
+		eventsService:   eventsService,
 	}
 
 	return &calendar, nil
@@ -87,9 +91,7 @@ func calendarID() string {
 }
 
 func (gc *googleCalendar) insertEnvent(event *gCalendar.Event) *gCalendar.EventsInsertCall {
-	eventsService := gCalendar.NewEventsService(gc.calendarService)
-
-	return eventsService.Insert(calendarID(), event)
+	return gc.eventsService.Insert(calendarID(), event)
 }
 
 //CreateCalendarEvent creates a event in Google Calendar

--- a/internal/calendar/google_calendar/calendar.go
+++ b/internal/calendar/google_calendar/calendar.go
@@ -48,8 +48,8 @@ func NewCalendar(
 		return nil, err
 	}
 
-	s := calendarService.(gCalendar.Service)
-	eventsService := google.NewCalendarEventsService(&s)
+	s := calendarService.(*gCalendar.Service)
+	eventsService := google.NewCalendarEventsService(s)
 
 	calendar := googleCalendar{
 		logger:          logger,

--- a/internal/calendar/google_calendar/calendar.go
+++ b/internal/calendar/google_calendar/calendar.go
@@ -3,6 +3,7 @@ package googlecalendar
 import (
 	"context"
 	"hellper/internal/calendar"
+	"hellper/internal/config"
 	googleauth "hellper/internal/google_auth"
 	"hellper/internal/log"
 
@@ -79,6 +80,16 @@ func event(start, end, summary string, emails []string, commander string) *gCale
 		End:       eventEnd,
 		Summary:   summary,
 	}
+}
+
+func calendarID() string {
+	return config.Env.GoogleCalendarID
+}
+
+func (gc *googleCalendar) insertEnvent(event *gCalendar.Event) *gCalendar.EventsInsertCall {
+	eventsService := gCalendar.NewEventsService(gc.calendarService)
+
+	return eventsService.Insert(calendarID(), event)
 }
 
 //CreateCalendarEvent creates a event in Google Calendar

--- a/internal/calendar/google_calendar/calendar.go
+++ b/internal/calendar/google_calendar/calendar.go
@@ -96,6 +96,7 @@ func event(start, end, summary string, emails []string, commander string) *gCale
 
 func (gc *googleCalendar) insertEnvent(event *gCalendar.Event) *gCalendar.EventsInsertCall {
 	return gc.eventsService.Insert(gc.calendarID, event)
+	//This function will also have all the calls related with the EventsInsertCall
 }
 
 //CreateCalendarEvent creates a event in Google Calendar

--- a/internal/google/calendar.go
+++ b/internal/google/calendar.go
@@ -1,0 +1,22 @@
+package google
+
+import (
+	"net/http"
+
+	"google.golang.org/api/calendar/v3"
+)
+
+type CalendarService interface {
+}
+
+type CalendarEventsService interface {
+	Insert(string, *calendar.Event) *calendar.EventsInsertCall
+}
+
+func NewCalendarEventsService(s *calendar.Service) CalendarEventsService {
+	return calendar.NewEventsService(s)
+}
+
+func NewCalendarService(client *http.Client) (CalendarService, error) {
+	return calendar.New(client)
+}

--- a/internal/google/calendar.go
+++ b/internal/google/calendar.go
@@ -6,17 +6,21 @@ import (
 	"google.golang.org/api/calendar/v3"
 )
 
+//CalendarService interfaces the Event struct from Google Calendar package
 type CalendarService interface {
 }
 
+//CalendarEventsService interfaces the EventsService struct from Google Calendar package
 type CalendarEventsService interface {
 	Insert(string, *calendar.Event) *calendar.EventsInsertCall
 }
 
+//NewCalendarEventsService calls the initializer for EventsService, from the Google Calendar package
 func NewCalendarEventsService(s *calendar.Service) CalendarEventsService {
 	return calendar.NewEventsService(s)
 }
 
+//NewCalendarService calls the initializer for Service, from the Google Calendar package
 func NewCalendarService(client *http.Client) (CalendarService, error) {
 	return calendar.New(client)
 }

--- a/internal/google/calendar_mock.go
+++ b/internal/google/calendar_mock.go
@@ -1,0 +1,27 @@
+package google
+
+import (
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/api/calendar/v3"
+)
+
+type CalendarEventsServiceMock struct {
+	mock.Mock
+}
+
+func NewCalendarEventsServiceMock() *CalendarEventsServiceMock {
+	return new(CalendarEventsServiceMock)
+}
+
+func (mock *CalendarEventsServiceMock) Insert(calendarID string, event *calendar.Event) *calendar.EventsInsertCall {
+	args := mock.Called(calendarID, event)
+	return args.Get(0).(*calendar.EventsInsertCall)
+}
+
+type CalendarServiceMock struct {
+	mock.Mock
+}
+
+func NewCalendarServiceMock() *CalendarServiceMock {
+	return new(CalendarServiceMock)
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -62,7 +62,11 @@ func NewFileStorage(logger log.Logger) filestorage.Driver {
 
 // NewCalendar creates a new connection with the calendar service
 func NewCalendar(ctx context.Context, logger log.Logger) calendar.Calendar {
-	calendar, err := googlecalendar.NewCalendar(ctx, logger, config.Env.GoogleCalendarToken)
+	var (
+		calendarToken = config.Env.GoogleCalendarToken
+		calendarID    = config.Env.GoogleCalendarID
+	)
+	calendar, err := googlecalendar.NewCalendar(ctx, logger, calendarToken, calendarID)
 	if err != nil {
 		logger.Error(
 			ctx,


### PR DESCRIPTION
### Description
Creates a simple function that calls the Insert method, from Google Calendar, and returns an EventsInsertCall.

For testing purpose, the 3rd party Google Calendar package was moved to a google package, that interfaces the methods, enabling mocks.

### How to test?
No other function is currently using the created one, but it has a unit test.

### Expected behavior
Everything must work as expected.
The tests must pass.