### PR TITLE
Private method to create a ConferenceSolutionKey of Google Meet type

### DIFF
--- a/internal/calendar/google_calendar/calendar.go
+++ b/internal/calendar/google_calendar/calendar.go
@@ -124,6 +124,12 @@ func (gc *googleCalendar) handleInsertEvent(ctx context.Context, insertCall goog
 	return gcEvent, nil
 }
 
+func googleMeetKey() *gCalendar.ConferenceSolutionKey {
+	return &gCalendar.ConferenceSolutionKey{
+		Type: "hangoutsMeet",
+	}
+}
+
 //CreateCalendarEvent creates a event in Google Calendar
 func (gc *googleCalendar) CreateCalendarEvent(ctx context.Context, start, end, summary, commander string, emails []string) (*model.Event, error) {
 	e := event(start, end, summary, commander, emails)

--- a/internal/calendar/google_calendar/calendar_test.go
+++ b/internal/calendar/google_calendar/calendar_test.go
@@ -58,6 +58,16 @@ func (f *googleCalendarFixture) setup(t *testing.T) {
 	f.calendarService = calendarServiceMock(f.mockLogger, f.mockCalendarService, f.mockCalendarEventsService, f.calendarID)
 }
 
+func TestGoogleMeetKey(t *testing.T) {
+	f := googleCalendarFixture{
+		testName: "ConferenceSolutionKey created",
+	}
+	t.Run(f.testName, func(t *testing.T) {
+		key := googleMeetKey()
+		assert.IsType(t, new(gCalendar.ConferenceSolutionKey), key)
+	})
+}
+
 // func TestInsertEvent(t *testing.T) {
 // 	f := googleCalendarFixture{
 // 		testName:   "The InsertCall is created without problem",


### PR DESCRIPTION
### Description
Creates a private method that returns a [ConferenceSolutionKey](https://godoc.org/google.golang.org/api/calendar/v3#ConferenceSolutionKey) struct, with the Type field as "hangoutsMeet" for a Google Meet conference.

### How to test?
This PR only creates a private method, that no other method calls yet.

### Expected behavior
Nothing in the default behavior should change.