### PR TITLE
Hydra users conversation struct

### DIFF
--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -39,9 +39,6 @@ func getSlackUserInfo(
 }
 
 func getUsersInConversationParameters(
-	ctx context.Context,
-	client bot.Client,
-	logger log.Logger,
 	channelID string,
 	cursor string,
 ) *slack.GetUsersInConversationParameters {

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"context"
 
+	"github.com/slack-go/slack"
+
 	"hellper/internal/bot"
 	"hellper/internal/log"
 	"hellper/internal/model"
@@ -34,4 +36,13 @@ func getSlackUserInfo(
 	}
 
 	return &user, err
+}
+
+func getUsersInConversationParameters(
+	ctx context.Context,
+	client bot.Client,
+	logger log.Logger,
+) *slack.GetUsersInConversationParameters {
+
+	return nil
 }

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -44,5 +44,5 @@ func getUsersInConversationParameters(
 	logger log.Logger,
 ) *slack.GetUsersInConversationParameters {
 
-	return nil
+	return &slack.GetUsersInConversationParameters{}
 }

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -42,7 +42,19 @@ func getUsersInConversationParameters(
 	ctx context.Context,
 	client bot.Client,
 	logger log.Logger,
+	channelID string,
+	cursor string,
 ) *slack.GetUsersInConversationParameters {
 
-	return &slack.GetUsersInConversationParameters{}
+	//Check if a cursor for a next page was received
+	if cursor != "" {
+		return &slack.GetUsersInConversationParameters{
+			ChannelID: channelID,
+			Cursor:    cursor,
+		}
+	}
+
+	return &slack.GetUsersInConversationParameters{
+		ChannelID: channelID,
+	}
 }


### PR DESCRIPTION
### Description
Creates a private function, that returns a struct of type [GetUsersInConversationParameters](https://godoc.org/github.com/slack-go/slack#GetUsersInConversationParameters) from package slack-go.

This returned struct can be one with only the ChannelID field or a struct with both ChannelID and Cursor, this decision is made if the cursor parameter is empty or not.

### How to test?
Private method. No public method is using it yet.

### Expected behavior
Everything should work just fine.