### PR TITLE
Adding getUsersInConversation

### DIFF
--- a/internal/bot/client.go
+++ b/internal/bot/client.go
@@ -19,4 +19,5 @@ type Client interface {
 	ArchiveChannel(channelID string) error
 	JoinConversation(string) (*slack.Channel, string, []string, error)
 	InviteUsersToConversation(string, ...string) (*slack.Channel, error)
+	GetUsersInConversationContext(context.Context, *slack.GetUsersInConversationParameters) ([]string, string, error)
 }

--- a/internal/bot/client_mock.go
+++ b/internal/bot/client_mock.go
@@ -72,6 +72,16 @@ func (mock *ClientMock) GetUserInfoContext(ctx context.Context, userID string) (
 	return result.(*slack.User), args.Error(1)
 }
 
+func (mock *ClientMock) GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
+	var (
+		args   = mock.Called(ctx, params)
+		list   = args.Get(0)
+		cursor = args.Get(1)
+		err    = args.Get(2)
+	)
+	return list.([]string), cursor.(string), err.(error)
+}
+
 func (mock *ClientMock) SetChannelTopic(channelID, topic string) (string, error) {
 	args := mock.Called(channelID, topic)
 	return args.String(0), args.Error(1)

--- a/internal/bot/client_mock.go
+++ b/internal/bot/client_mock.go
@@ -77,9 +77,9 @@ func (mock *ClientMock) GetUsersInConversationContext(ctx context.Context, param
 		args   = mock.Called(ctx, params)
 		list   = args.Get(0)
 		cursor = args.Get(1)
-		err    = args.Get(2)
+		err    = args.Error(2)
 	)
-	return list.([]string), cursor.(string), err.(error)
+	return list.([]string), cursor.(string), err
 }
 
 func (mock *ClientMock) SetChannelTopic(channelID, topic string) (string, error) {

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -43,7 +43,7 @@ func getUsersInConversation(
 	client bot.Client,
 	logger log.Logger,
 	channelID string,
-) *[]string {
+) (*[]string, error) {
 	logger.Info(
 		ctx,
 		"command/user.getUsersInConversation",
@@ -65,7 +65,7 @@ func getUsersInConversation(
 				log.NewValue("channelID", channelID),
 				log.NewValue("error", err),
 			)
-			break
+			return nil, err
 		}
 		members = append(members, list...)
 		if cursor == "" {
@@ -75,5 +75,5 @@ func getUsersInConversation(
 		}
 	}
 
-	return &members
+	return &members, nil
 }


### PR DESCRIPTION
### Description
<!--- Provide a minimal description of the changes or addition you are proposing in your pull request. -->
<!--- If it is related with a bug/issue fix, do not forget to link the issue in the description. -->
In this PR the func getUsersInConversation was added.
This function has the responsibility of only listing the users IDs within a channel.

### How to test?
<!--- Provide a step by step to be followed that reproduce your feature/code changes to make the review easier. -->
If you want to test the function created, you can use this example:
```go
usersInConversation := getUsersInConversation(ctx, client, logger, channelID)
logger.Info(
	ctx,
	"command/resolve.ResolveIncidentByDialog",
	log.NewValue("usersInConversation", *usersInConversation),
)
```

Example with log
```
{"level":"info","time":"2020-06-23T16:59:53.082Z","message":"command/resolve.ResolveIncidentByDialog","usersInConversation":["UT83647QV","U01030886D7"]}
```

### Expected behavior
<!--- Provide a minimal description of what will be achieved with the PR -->
This PR does not change any behavior.
