### PR TITLE
Pinning the reason in the pause command

### DIFF
--- a/internal/commands/pause_notify.go
+++ b/internal/commands/pause_notify.go
@@ -79,6 +79,7 @@ func PauseNotifyIncidentByDialog(
 	var (
 		channelID             = incidentDetails.Channel.ID
 		userID                = incidentDetails.User.ID
+		userName              = incidentDetails.User.Name
 		submissions           = incidentDetails.Submission
 		pauseNotifyTimeText   = submissions.PauseNotifyTime
 		pauseNotifyReasonText = submissions.PauseNotifyReason
@@ -128,7 +129,7 @@ func PauseNotifyIncidentByDialog(
 		return err
 	}
 
-	PostInfoAttachment(ctx, client, channelID, userID, "Ops", "This command is not ready yet")
+	postAndPinMessage(client, channelID, "Hellper notifications has been paused by <@"+userName+"> until *"+incident.SnoozedAt.Format(time.RFC1123)+"* for the following reason:\n```\n"+pauseNotifyReasonText+"\n```")
 	return nil
 }
 


### PR DESCRIPTION
### Description
<!--- Provide a minimal description of the changes or addition you are proposing in your pull request. -->
<!--- If it is related with a bug/issue fix, do not forget to link the issue in the description. -->
This PR has the responsibility to pin the message on the incident channel.

Specifically in our SlackApp the scope is not configured to pin the message on the incident channel, but you can test it in your development environment.

### How to test?
<!--- Provide a step by step to be followed that reproduce your feature/code changes to make the review easier. -->
* Deploy in staging
* Create a new incident test
* Pause the incident with command: `/staging_hellper_pause_notify` to test

### Expected behavior
<!--- Provide a minimal description of what will be achieved with the PR -->

Slackbot should send a message and pin it on the channel:

![image](https://user-images.githubusercontent.com/31517712/87075992-8626e400-c1f7-11ea-8ce5-3cba1ad41226.png)
