### PR TITLE
Conversion API migration

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -85,9 +85,6 @@ github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
@@ -105,8 +102,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lib/pq v1.5.2 h1:yTSXVswvWUOQ3k1sd7vJfDrbSl8lKuscqFJRqjC0ifw=
-github.com/lib/pq v1.5.2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.7.0 h1:h93mCPfUSkaul3Ka/VG8uZdmW1uMHDGxzu0NWHuJmHY=
 github.com/lib/pq v1.7.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/paked/configure v0.0.0-20190218140148-28f9c3f21a44 h1:kjzfKpM4fElkBIN77VEjv1VXpAEQhYLrhjex/by6aOU=
@@ -118,8 +113,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/slack-go/slack v0.6.4 h1:cxOqFgM5RW6mdEyDqAJutFk3qiORK9oHRKi5bPqkY9o=
-github.com/slack-go/slack v0.6.4/go.mod h1:sGRjv3w+ERAUMMMbldHObQPBcNSyVB7KLKYfnwUFBfw=
 github.com/slack-go/slack v0.6.5 h1:IkDKtJ2IROJNoe3d6mW870/NRKvq2fhLB/Q5XmzWk00=
 github.com/slack-go/slack v0.6.5/go.mod h1:FGqNzJBmxIsZURAxh2a8D21AnOVvvXZvGligs4npPUM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -130,8 +123,6 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -299,12 +290,6 @@ google.golang.org/api v0.15.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsb
 google.golang.org/api v0.17.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.18.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
-google.golang.org/api v0.25.0 h1:LodzhlzZEUfhXzNUMIfVlf9Gr6Ua5MMtoFWh7+f47qA=
-google.golang.org/api v0.25.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
-google.golang.org/api v0.26.0 h1:VJZ8h6E8ip82FRpQl848c5vAadxlTXrUh8RzQzSRm08=
-google.golang.org/api v0.26.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
-google.golang.org/api v0.27.0 h1:L02vxokXh9byvvyTw3PLA4MmNri7cY29nliyK4MnIxY=
-google.golang.org/api v0.27.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.28.0 h1:jMF5hhVfMkTZwHW1SDpKq5CkgWLXOb31Foaca9Zr3oM=
 google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/internal/bot/client.go
+++ b/internal/bot/client.go
@@ -18,6 +18,5 @@ type Client interface {
 	AddPin(string, slack.ItemRef) error
 	ArchiveConversationContext(ctx context.Context, channelID string) error
 	JoinConversationContext(ctx context.Context, channelID string) (*slack.Channel, string, []string, error)
-	InviteUsersToConversation(string, ...string) (*slack.Channel, error)
 	GetUsersInConversationContext(context.Context, *slack.GetUsersInConversationParameters) ([]string, string, error)
 }

--- a/internal/bot/client.go
+++ b/internal/bot/client.go
@@ -9,8 +9,8 @@ import (
 type Client interface {
 	PostEphemeralContext(context.Context, string, string, ...slack.MsgOption) (string, error)
 	PostMessage(string, ...slack.MsgOption) (string, string, error)
-	CreateConversationContext(context.Context, string, bool) (*slack.Channel, error)
-	InviteUserToChannel(string, string) (*slack.Channel, error)
+	CreateConversationContext(ctx context.Context, channelName string, isPrivate bool) (*slack.Channel, error)
+	InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*slack.Channel, error)
 	ListPins(string) ([]slack.Item, *slack.Paging, error)
 	GetUserInfoContext(context.Context, string) (*slack.User, error)
 	SetChannelTopic(string, string) (string, error)

--- a/internal/bot/client.go
+++ b/internal/bot/client.go
@@ -16,7 +16,7 @@ type Client interface {
 	SetTopicOfConversationContext(ctx context.Context, channelID, topic string) (*slack.Channel, error)
 	OpenDialog(string, slack.Dialog) error
 	AddPin(string, slack.ItemRef) error
-	ArchiveChannel(channelID string) error
+	ArchiveConversationContext(ctx context.Context, channelID string) error
 	JoinConversation(string) (*slack.Channel, string, []string, error)
 	InviteUsersToConversation(string, ...string) (*slack.Channel, error)
 	GetUsersInConversationContext(context.Context, *slack.GetUsersInConversationParameters) ([]string, string, error)

--- a/internal/bot/client.go
+++ b/internal/bot/client.go
@@ -17,7 +17,7 @@ type Client interface {
 	OpenDialog(string, slack.Dialog) error
 	AddPin(string, slack.ItemRef) error
 	ArchiveConversationContext(ctx context.Context, channelID string) error
-	JoinConversation(string) (*slack.Channel, string, []string, error)
+	JoinConversationContext(ctx context.Context, channelID string) (*slack.Channel, string, []string, error)
 	InviteUsersToConversation(string, ...string) (*slack.Channel, error)
 	GetUsersInConversationContext(context.Context, *slack.GetUsersInConversationParameters) ([]string, string, error)
 }

--- a/internal/bot/client.go
+++ b/internal/bot/client.go
@@ -9,7 +9,7 @@ import (
 type Client interface {
 	PostEphemeralContext(context.Context, string, string, ...slack.MsgOption) (string, error)
 	PostMessage(string, ...slack.MsgOption) (string, string, error)
-	CreateChannel(string) (*slack.Channel, error)
+	CreateConversationContext(context.Context, string, bool) (*slack.Channel, error)
 	InviteUserToChannel(string, string) (*slack.Channel, error)
 	ListPins(string) ([]slack.Item, *slack.Paging, error)
 	GetUserInfoContext(context.Context, string) (*slack.User, error)

--- a/internal/bot/client.go
+++ b/internal/bot/client.go
@@ -13,7 +13,7 @@ type Client interface {
 	InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*slack.Channel, error)
 	ListPins(string) ([]slack.Item, *slack.Paging, error)
 	GetUserInfoContext(context.Context, string) (*slack.User, error)
-	SetChannelTopic(string, string) (string, error)
+	SetTopicOfConversationContext(ctx context.Context, channelID, topic string) (*slack.Channel, error)
 	OpenDialog(string, slack.Dialog) error
 	AddPin(string, slack.ItemRef) error
 	ArchiveChannel(channelID string) error

--- a/internal/bot/client_mock.go
+++ b/internal/bot/client_mock.go
@@ -83,9 +83,15 @@ func (mock *ClientMock) GetUsersInConversationContext(ctx context.Context, param
 	return list.([]string), cursor.(string), err
 }
 
-func (mock *ClientMock) SetChannelTopic(channelID, topic string) (string, error) {
-	args := mock.Called(channelID, topic)
-	return args.String(0), args.Error(1)
+func (mock *ClientMock) SetTopicOfConversationContext(ctx context.Context, channelID, topic string) (*slack.Channel, error) {
+	var (
+		args   = mock.Called(ctx, channelID, topic)
+		result = args.Get(0)
+	)
+	if result == nil {
+		return nil, args.Error(1)
+	}
+	return result.(*slack.Channel), args.Error(1)
 }
 
 func (mock *ClientMock) OpenDialog(triggerID string, dialog slack.Dialog) error {

--- a/internal/bot/client_mock.go
+++ b/internal/bot/client_mock.go
@@ -114,8 +114,9 @@ func (mock *ClientMock) PostEphemeralContext(ctx context.Context, channelID stri
 	return args.String(0), args.Error(1)
 }
 
-func (mock *ClientMock) JoinConversation(string) (*slack.Channel, string, []string, error) {
-	return nil, "", nil, nil
+func (mock *ClientMock) JoinConversationContext(ctx context.Context, channelID string) (*slack.Channel, string, []string, error) {
+	args := mock.Called(ctx, channelID)
+	return args.Get(0).(*slack.Channel), args.String(1), args.Get(2).([]string), args.Error(3)
 }
 
 func (mock *ClientMock) InviteUsersToConversation(string, ...string) (*slack.Channel, error) {

--- a/internal/bot/client_mock.go
+++ b/internal/bot/client_mock.go
@@ -22,14 +22,15 @@ func (mock *ClientMock) PostMessage(
 	return args.String(0), args.String(1), args.Error(2)
 }
 
-func (mock *ClientMock) CreateChannel(name string) (*slack.Channel, error) {
+func (mock *ClientMock) CreateConversationContext(ctx context.Context, channelName string, isPrivate bool) (*slack.Channel, error) {
 	var (
-		args   = mock.Called(name)
+		args   = mock.Called(ctx, channelName, isPrivate)
 		result = args.Get(0)
 	)
 	if result == nil {
 		return nil, args.Error(1)
 	}
+
 	return result.(*slack.Channel), args.Error(1)
 }
 

--- a/internal/bot/client_mock.go
+++ b/internal/bot/client_mock.go
@@ -118,7 +118,3 @@ func (mock *ClientMock) JoinConversationContext(ctx context.Context, channelID s
 	args := mock.Called(ctx, channelID)
 	return args.Get(0).(*slack.Channel), args.String(1), args.Get(2).([]string), args.Error(3)
 }
-
-func (mock *ClientMock) InviteUsersToConversation(string, ...string) (*slack.Channel, error) {
-	return nil, nil
-}

--- a/internal/bot/client_mock.go
+++ b/internal/bot/client_mock.go
@@ -34,9 +34,9 @@ func (mock *ClientMock) CreateConversationContext(ctx context.Context, channelNa
 	return result.(*slack.Channel), args.Error(1)
 }
 
-func (mock *ClientMock) InviteUserToChannel(channelID string, userID string) (*slack.Channel, error) {
+func (mock *ClientMock) InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*slack.Channel, error) {
 	var (
-		args   = mock.Called(channelID, userID)
+		args   = mock.Called(ctx, channelID, users)
 		result = args.Get(0)
 	)
 	if result == nil {

--- a/internal/bot/client_mock.go
+++ b/internal/bot/client_mock.go
@@ -104,8 +104,9 @@ func (mock *ClientMock) AddPin(channel string, item slack.ItemRef) error {
 	return args.Error(0)
 }
 
-func (mock *ClientMock) ArchiveChannel(channelID string) error {
-	return nil
+func (mock *ClientMock) ArchiveConversationContext(ctx context.Context, channelID string) error {
+	args := mock.Called(ctx, channelID)
+	return args.Error(0)
 }
 
 func (mock *ClientMock) PostEphemeralContext(ctx context.Context, channelID string, userID string, options ...slack.MsgOption) (string, error) {

--- a/internal/commands/cancel.go
+++ b/internal/commands/cancel.go
@@ -77,9 +77,7 @@ func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.L
 	postAndPinMessage(client, channelID, "", attachment)
 	postAndPinMessage(client, config.Env.ProductChannelID, "", attachment)
 	repository.CancelIncident(ctx, channelID, description)
-	client.ArchiveChannel(channelID)
-
-	client.ArchiveChannel(channelID)
+	client.ArchiveConversationContext(ctx, channelID)
 
 	return nil
 }

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -214,7 +214,11 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 	})
 
 	postAndPinMessage(client, channelID, "", channelAttachment)
-	client.ArchiveChannel(channelID)
+	err = client.ArchiveConversationContext(ctx, channelID)
+	if err != nil {
+		PostErrorAttachment(ctx, client, logger, channelID, userID, err.Error())
+		return err
+	}
 
 	repository.CloseIncident(ctx, &incident)
 

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -216,6 +216,13 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 	postAndPinMessage(client, channelID, "", channelAttachment)
 	err = client.ArchiveConversationContext(ctx, channelID)
 	if err != nil {
+		logger.Error(
+			ctx,
+			"command/close.CloseIncidentByDialog ArchiveConversationContext ERROR",
+			log.NewValue("channelID", channelID),
+			log.NewValue("userID", userID),
+			log.NewValue("error", err),
+		)
 		PostErrorAttachment(ctx, client, logger, channelID, userID, err.Error())
 		return err
 	}

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -42,7 +42,7 @@ func (scenario *testCommand) setup(t *testing.T) {
 
 	mockChannel.ID = "mockChannel"
 	mockChannel.Name = "Mock Channel Name"
-	slackMock.On("CreateChannel", mock.AnythingOfType("string")).Return(&mockChannel, nil)
+	slackMock.On("CreateConversationContext", mock.AnythingOfType("context.Context"), mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return(&mockChannel, nil)
 	slackMock.On("PostMessage", mock.AnythingOfType("string"), mock.Anything).Return(
 		scenario.trigger.Channel, time.Now().Format(time.RFC3339), nil,
 	)

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 type testCommand struct {
+	ctx            context.Context
 	name           string
 	command        string
 	trigger        TriggerEvent
@@ -39,20 +40,18 @@ func (scenario *testCommand) setup(t *testing.T) {
 		repositoryMock = model.NewRepositoryMock()
 		mockChannel    = slack.Channel{}
 	)
+	scenario.ctx = context.Background()
 
 	mockChannel.ID = "mockChannel"
 	mockChannel.Name = "Mock Channel Name"
-	slackMock.On("CreateConversationContext", mock.AnythingOfType("context.Context"), mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return(&mockChannel, nil)
+	slackMock.On("CreateConversationContext", scenario.ctx, mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return(&mockChannel, nil)
 	slackMock.On("PostMessage", mock.AnythingOfType("string"), mock.Anything).Return(
 		scenario.trigger.Channel, time.Now().Format(time.RFC3339), nil,
 	)
 	slackMock.On(
-		"InviteUsersToConversationContext", mock.AnythingOfType("context.Context"), mock.AnythingOfType("string"), mock.AnythingOfType("string"),
+		"InviteUsersToConversationContext", scenario.ctx, mock.AnythingOfType("string"), mock.AnythingOfType("string"),
 	).Return(&mockChannel, nil)
 	slackMock.On("ListPins", mock.AnythingOfType("string")).Return([]slack.Item{}, nil, nil)
-	slackMock.On(
-		"SetChannelTopic", mock.AnythingOfType("string"), mock.AnythingOfType("string"),
-	).Return(scenario.trigger.Channel, nil)
 
 	repositoryMock.On("SetIncident", mock.AnythingOfType("*model.Incident")).Return(nil)
 	repositoryMock.On("GetIncident", mock.AnythingOfType("string")).Return(model.Incident{}, nil)

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -47,7 +47,7 @@ func (scenario *testCommand) setup(t *testing.T) {
 		scenario.trigger.Channel, time.Now().Format(time.RFC3339), nil,
 	)
 	slackMock.On(
-		"InviteUserToChannel", mock.AnythingOfType("string"), mock.AnythingOfType("string"),
+		"InviteUsersToConversationContext", mock.AnythingOfType("context.Context"), mock.AnythingOfType("string"), mock.AnythingOfType("string"),
 	).Return(&mockChannel, nil)
 	slackMock.On("ListPins", mock.AnythingOfType("string")).Return([]slack.Item{}, nil, nil)
 	slackMock.On(

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -234,7 +234,7 @@ func StartIncidentByDialog(
 		return err
 	}
 
-	_, err = client.InviteUsersToConversation(channel.ID, commander)
+	_, err = client.InviteUsersToConversationContext(ctx, channel.ID, commander)
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -168,9 +168,9 @@ func StartIncidentByDialog(
 		return fmt.Errorf("commands.StartIncidentByDialog.get_slack_user_info: incident=%v commanderId=%v error=%v", channelName, commander, err)
 	}
 
-	channel, err := client.CreateChannel(channelName)
+	channel, err := client.CreateConversationContext(ctx, channelName, false)
 	if err != nil {
-		return fmt.Errorf("commands.StartIncidentByDialog.create_channel: incident=%v error=%v", channelName, err)
+		return fmt.Errorf("commands.StartIncidentByDialog.create_conversation_context: incident=%v error=%v", channelName, err)
 	}
 
 	severityLevelInt64, err := getStringInt64(severityLevel)

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -263,7 +263,7 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 	topic.WriteString("*War Room:* " + warRoomURL + "\n\n")
 	topic.WriteString("*Post Mortem URL:* " + postMortemURL + "\n\n")
 
-	_, err = client.SetChannelTopic(channel.ID, topic.String())
+	_, err = client.SetTopicOfConversationContext(ctx, channel.ID, topic.String())
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -222,7 +222,7 @@ func StartIncidentByDialog(
 
 	startReminderStatusJob(ctx, logger, client, repository, incident)
 
-	_, warning, metaWarning, err := client.JoinConversation(channel.ID)
+	_, warning, metaWarning, err := client.JoinConversationContext(ctx, channel.ID)
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/handler/events_test.go
+++ b/internal/handler/events_test.go
@@ -46,7 +46,9 @@ func (scenario *testHandler) setup(*testing.T) {
 		mock.Anything,
 	).Return("mockChannel", time.Now().Format(time.RFC3339), nil)
 	slackMock.On("CreateConversationContext", mock.AnythingOfType("context.Context"), mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return(new(slack.Channel), nil).Once()
-	slackMock.On("InviteUserToChannel",
+	slackMock.On(
+		"InviteUsersToConversationContext",
+		mock.AnythingOfType("context.Context"),
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),
 	).Return(

--- a/internal/handler/events_test.go
+++ b/internal/handler/events_test.go
@@ -45,7 +45,7 @@ func (scenario *testHandler) setup(*testing.T) {
 		mock.AnythingOfType("string"),
 		mock.Anything,
 	).Return("mockChannel", time.Now().Format(time.RFC3339), nil)
-	slackMock.On("CreateChannel", mock.AnythingOfType("string")).Return(new(slack.Channel), nil).Once()
+	slackMock.On("CreateConversationContext", mock.AnythingOfType("context.Context"), mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return(new(slack.Channel), nil).Once()
 	slackMock.On("InviteUserToChannel",
 		mock.AnythingOfType("string"),
 		mock.AnythingOfType("string"),


### PR DESCRIPTION
### Description
Resolves debt #40 

This PR changes the Slack methods, that were deprecated in favor of Conversation API: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api?utm_medium=email&utm_source=newsletter&utm_campaign=fy21-Q205-changelog

### How to test?
Nothing should change.

### Expected behavior
Everything should work as usual.