### PR TITLE
Hydra add incident commander inc topic

### DIFF
--- a/internal/bot/client.go
+++ b/internal/bot/client.go
@@ -13,7 +13,7 @@ type Client interface {
 	InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*slack.Channel, error)
 	ListPins(string) ([]slack.Item, *slack.Paging, error)
 	GetUserInfoContext(context.Context, string) (*slack.User, error)
-	SetTopicOfConversationContext(ctx context.Context, channelID, topic string) (*slack.Channel, error)
+	SetTopicOfConversation(channelID, topic string) (*slack.Channel, error)
 	OpenDialog(string, slack.Dialog) error
 	AddPin(string, slack.ItemRef) error
 	ArchiveConversationContext(ctx context.Context, channelID string) error

--- a/internal/bot/client_mock.go
+++ b/internal/bot/client_mock.go
@@ -83,9 +83,9 @@ func (mock *ClientMock) GetUsersInConversationContext(ctx context.Context, param
 	return list.([]string), cursor.(string), err
 }
 
-func (mock *ClientMock) SetTopicOfConversationContext(ctx context.Context, channelID, topic string) (*slack.Channel, error) {
+func (mock *ClientMock) SetTopicOfConversation(channelID, topic string) (*slack.Channel, error) {
 	var (
-		args   = mock.Called(ctx, channelID, topic)
+		args   = mock.Called(channelID, topic)
 		result = args.Get(0)
 	)
 	if result == nil {

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -218,7 +218,7 @@ func StartIncidentByDialog(
 	})
 
 	//We need run that without wait because the modal need close in only 3s
-	go createPostMortemAndUpdateTopic(ctx, logger, client, fileStorage, incidentID, repository, channel, warRoomURL)
+	go createPostMortemAndUpdateTopic(model.Incident{}, ctx, logger, client, fileStorage, incidentID, repository, channel, warRoomURL)
 
 	startReminderStatusJob(ctx, logger, client, repository, incident)
 

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -1,4 +1,4 @@
-package commands
+opackage commands
 
 import (
 	"context"
@@ -247,7 +247,7 @@ func StartIncidentByDialog(
 	return nil
 }
 
-func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incidentID int64, CommanderID string, repository model.Repository, channel *slack.Channel, warRoomURL string) {
+func createPostMortemAndUpdateTopic(incident model.Incident, ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incidentID int64, repository model.Repository, channel *slack.Channel, warRoomURL string) {
 	postMortemURL, err := createPostMortem(ctx, logger, client, fileStorage, incidentID, channel.Name, repository, channel.Name)
 	if err != nil {
 		logger.Error(
@@ -262,7 +262,7 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 	var topic strings.Builder
 	topic.WriteString("*War Room:* " + warRoomURL + "\n\n")
 	topic.WriteString("*Post Mortem URL:* " + postMortemURL + "\n\n")
-	topic.WriteString("*Commander:* <@" + CommanderID + ">\n\n")
+	topic.WriteString("*Commander:* <@" + incident.CommanderId + ">\n\n")
 
 	_, err = client.SetTopicOfConversation(channel.ID, topic.String())
 	if err != nil {

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -218,7 +218,7 @@ func StartIncidentByDialog(
 	})
 
 	//We need run that without wait because the modal need close in only 3s
-	go createPostMortemAndUpdateTopic(ctx, logger, client, fileStorage, incident, user.SlackID, incidentID, repository, channel, warRoomURL)
+	go createPostMortemAndUpdateTopic(ctx, logger, client, fileStorage, incident, incidentID, repository, channel, warRoomURL)
 
 	startReminderStatusJob(ctx, logger, client, repository, incident)
 
@@ -247,7 +247,7 @@ func StartIncidentByDialog(
 	return nil
 }
 
-func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incident model.Incident, userID string, incidentID int64, repository model.Repository, channel *slack.Channel, warRoomURL string) {
+func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incident model.Incident, incidentID int64, repository model.Repository, channel *slack.Channel, warRoomURL string) {
 	postMortemURL, err := createPostMortem(ctx, logger, client, fileStorage, incidentID, channel.Name, repository, channel.Name)
 	if err != nil {
 		logger.Error(
@@ -263,7 +263,6 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 	topic.WriteString("*War Room:* " + warRoomURL + "\n\n")
 	topic.WriteString("*Post Mortem URL:* " + postMortemURL + "\n\n")
 	topic.WriteString("*Commander:* <@" + incident.CommanderId + ">\n\n")
-	topic.WriteString("*User:* <@" + userID + ">\n\n")
 
 	_, err = client.SetTopicOfConversation(channel.ID, topic.String())
 	if err != nil {

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -248,27 +248,23 @@ func StartIncidentByDialog(
 }
 
 func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incident model.Incident, incidentID int64, repository model.Repository, channel *slack.Channel, warRoomURL string) {
-	// postMortemURL, err := createPostMortem(ctx, logger, client, fileStorage, incidentID, channel.Name, repository, channel.Name)
-	// if err != nil {
-	// 	logger.Error(
-	// 		ctx,
-	// 		"command/open.create_post_mortem ERROR",
-	// 		log.NewValue("channel_name", channel.Name),
-	// 		log.NewValue("error", err),
-	// 	)
-	// 	return
-	// }
+	postMortemURL, err := createPostMortem(ctx, logger, client, fileStorage, incidentID, channel.Name, repository, channel.Name)
+	if err != nil {
+		logger.Error(
+			ctx,
+			"command/open.create_post_mortem ERROR",
+			log.NewValue("channel_name", channel.Name),
+			log.NewValue("error", err),
+		)
+		return
+	}
 
 	var topic strings.Builder
-	// topic.WriteString("*War Room:* " + warRoomURL + "\n\n")
-	// topic.WriteString("*Post Mortem URL:* " + postMortemURL + "\n\n")
+	topic.WriteString("*WarRoom:* " + warRoomURL + "\n\n")
+	topic.WriteString("*PostMortem:* " + postMortemURL + "\n\n")
 	topic.WriteString("*Commander:* <@" + incident.CommanderId + ">\n\n")
-	logger.Info(ctx,
-		"teste-commander-id",
-		log.NewValue("error", incident.CommanderId),
-	)
 
-	_, err := client.SetTopicOfConversation(channel.ID, topic.String())
+	_, err = client.SetTopicOfConversation(channel.ID, topic.String())
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -247,7 +247,7 @@ func StartIncidentByDialog(
 	return nil
 }
 
-func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incidentID int64, repository model.Repository, channel *slack.Channel, warRoomURL string) {
+func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incidentID int64, CommanderID string, repository model.Repository, channel *slack.Channel, warRoomURL string) {
 	postMortemURL, err := createPostMortem(ctx, logger, client, fileStorage, incidentID, channel.Name, repository, channel.Name)
 	if err != nil {
 		logger.Error(
@@ -262,6 +262,7 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 	var topic strings.Builder
 	topic.WriteString("*War Room:* " + warRoomURL + "\n\n")
 	topic.WriteString("*Post Mortem URL:* " + postMortemURL + "\n\n")
+	topic.WriteString("*Commander:* <@" + CommanderID + ">\n\n")
 
 	_, err = client.SetTopicOfConversation(channel.ID, topic.String())
 	if err != nil {

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -1,4 +1,4 @@
-opackage commands
+package commands
 
 import (
 	"context"

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -248,30 +248,31 @@ func StartIncidentByDialog(
 }
 
 func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incident model.Incident, incidentID int64, repository model.Repository, channel *slack.Channel, warRoomURL string) {
-	postMortemURL, err := createPostMortem(ctx, logger, client, fileStorage, incidentID, channel.Name, repository, channel.Name)
-	if err != nil {
-		logger.Error(
-			ctx,
-			"command/open.create_post_mortem ERROR",
-			log.NewValue("channel_name", channel.Name),
-			log.NewValue("error", err),
-		)
-		return
-	}
+	// postMortemURL, err := createPostMortem(ctx, logger, client, fileStorage, incidentID, channel.Name, repository, channel.Name)
+	// if err != nil {
+	// 	logger.Error(
+	// 		ctx,
+	// 		"command/open.create_post_mortem ERROR",
+	// 		log.NewValue("channel_name", channel.Name),
+	// 		log.NewValue("error", err),
+	// 	)
+	// 	return
+	// }
 
 	var topic strings.Builder
-	topic.WriteString("*War Room:* " + warRoomURL + "\n\n")
-	topic.WriteString("*Post Mortem URL:* " + postMortemURL + "\n\n")
+	// topic.WriteString("*War Room:* " + warRoomURL + "\n\n")
+	// topic.WriteString("*Post Mortem URL:* " + postMortemURL + "\n\n")
 	topic.WriteString("*Commander:* <@" + incident.CommanderId + ">\n\n")
+	logger.Info(ctx, incident.CommanderId)
 
-	_, err = client.SetTopicOfConversation(channel.ID, topic.String())
-	if err != nil {
-		logger.Error(
-			ctx,
-			"command/open.set_channel_topic_error",
-			log.NewValue("error", err),
-		)
-	}
+	// _, err = client.SetTopicOfConversation(channel.ID, topic.String())
+	// if err != nil {
+	// 	logger.Error(
+	// 		ctx,
+	// 		"command/open.set_channel_topic_error",
+	// 		log.NewValue("error", err),
+	// 	)
+	// }
 }
 
 func createOpenAttachment(incident model.Incident, incidentID int64, warRoomURL string, supportTeam string) slack.Attachment {

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -218,7 +218,7 @@ func StartIncidentByDialog(
 	})
 
 	//We need run that without wait because the modal need close in only 3s
-	go createPostMortemAndUpdateTopic(model.Incident{}, ctx, logger, client, fileStorage, incidentID, repository, channel, warRoomURL)
+	go createPostMortemAndUpdateTopic(incident, ctx, logger, client, fileStorage, incidentID, repository, channel, warRoomURL)
 
 	startReminderStatusJob(ctx, logger, client, repository, incident)
 

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -263,16 +263,19 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 	// topic.WriteString("*War Room:* " + warRoomURL + "\n\n")
 	// topic.WriteString("*Post Mortem URL:* " + postMortemURL + "\n\n")
 	topic.WriteString("*Commander:* <@" + incident.CommanderId + ">\n\n")
-	logger.Info(ctx, incident.CommanderId)
+	logger.Info(ctx,
+		"teste-commander-id",
+		log.NewValue("error", incident.CommanderId),
+	)
 
-	// _, err = client.SetTopicOfConversation(channel.ID, topic.String())
-	// if err != nil {
-	// 	logger.Error(
-	// 		ctx,
-	// 		"command/open.set_channel_topic_error",
-	// 		log.NewValue("error", err),
-	// 	)
-	// }
+	_, err := client.SetTopicOfConversation(channel.ID, topic.String())
+	if err != nil {
+		logger.Error(
+			ctx,
+			"command/open.set_channel_topic_error",
+			log.NewValue("error", err),
+		)
+	}
 }
 
 func createOpenAttachment(incident model.Incident, incidentID int64, warRoomURL string, supportTeam string) slack.Attachment {

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -263,7 +263,7 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 	topic.WriteString("*War Room:* " + warRoomURL + "\n\n")
 	topic.WriteString("*Post Mortem URL:* " + postMortemURL + "\n\n")
 
-	_, err = client.SetTopicOfConversationContext(ctx, channel.ID, topic.String())
+	_, err = client.SetTopicOfConversation(channel.ID, topic.String())
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -218,7 +218,7 @@ func StartIncidentByDialog(
 	})
 
 	//We need run that without wait because the modal need close in only 3s
-	go createPostMortemAndUpdateTopic(incident, ctx, logger, client, fileStorage, incidentID, repository, channel, warRoomURL)
+	go createPostMortemAndUpdateTopic(ctx, logger, client, fileStorage, incident, user.SlackID, incidentID, repository, channel, warRoomURL)
 
 	startReminderStatusJob(ctx, logger, client, repository, incident)
 
@@ -247,7 +247,7 @@ func StartIncidentByDialog(
 	return nil
 }
 
-func createPostMortemAndUpdateTopic(incident model.Incident, ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incidentID int64, repository model.Repository, channel *slack.Channel, warRoomURL string) {
+func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incident model.Incident, userID string, incidentID int64, repository model.Repository, channel *slack.Channel, warRoomURL string) {
 	postMortemURL, err := createPostMortem(ctx, logger, client, fileStorage, incidentID, channel.Name, repository, channel.Name)
 	if err != nil {
 		logger.Error(
@@ -263,6 +263,7 @@ func createPostMortemAndUpdateTopic(incident model.Incident, ctx context.Context
 	topic.WriteString("*War Room:* " + warRoomURL + "\n\n")
 	topic.WriteString("*Post Mortem URL:* " + postMortemURL + "\n\n")
 	topic.WriteString("*Commander:* <@" + incident.CommanderId + ">\n\n")
+	topic.WriteString("*User:* <@" + userID + ">\n\n")
 
 	_, err = client.SetTopicOfConversation(channel.ID, topic.String())
 	if err != nil {


### PR DESCRIPTION
### Description

This PR fix the Topic Messages in channel, and adds the Commander ID into the topic of the incident channel in Slack Apps.

### How to test?
1. Deploy this PR in stagging or dev environment;
2. Create a incident;
3. Test if the messages are fixed in topic (Warroom, PostMortem URL and Commander)

### Expected behavior

WarRoom URL, PostMortem URL And Incident Commander will be fixed in the message topic of the incident channel.