### PR TITLE
Check incident status before cancel

### DIFF
--- a/internal/commands/cancel.go
+++ b/internal/commands/cancel.go
@@ -29,6 +29,7 @@ func OpenCancelIncidentDialog(
 			ctx,
 			"command/dates.OpenCancelIncidentDialog GetIncident ERROR",
 			log.NewValue("channelID", channelID),
+			log.NewValue("userID", userID),
 			log.NewValue("error", err),
 		)
 
@@ -51,7 +52,21 @@ func OpenCancelIncidentDialog(
 			Fields:   []slack.AttachmentField{},
 		}
 
-		return postMessage(client, channelID, "", attch)
+		_, err = client.PostEphemeralContext(ctx, channelID, userID, slack.MsgOptionAttachments(attch))
+		if err != nil {
+			logger.Error(
+				ctx,
+				"command/dates.OpenCancelIncidentDialog PostEphemeralContext ERROR",
+				log.NewValue("channelID", channelID),
+				log.NewValue("userID", userID),
+				log.NewValue("error", err),
+			)
+
+			PostErrorAttachment(ctx, client, logger, channelID, userID, err.Error())
+			return err
+		}
+
+		return nil
 	}
 
 	description := &slack.TextInputElement{

--- a/internal/handler/cancel.go
+++ b/internal/handler/cancel.go
@@ -53,8 +53,10 @@ func (h *handlerCancel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 
 	tiggerID := r.FormValue("trigger_id")
+	channelID := r.FormValue("channel_id")
+	userID := r.FormValue("user_id")
 
-	err := commands.OpenCancelIncidentDialog(h.client, tiggerID)
+	err := commands.OpenCancelIncidentDialog(ctx, logger, h.client, h.repository, channelID, userID, tiggerID)
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/handler/route.go
+++ b/internal/handler/route.go
@@ -69,7 +69,8 @@ func NewHandlerRoute() func(http.ResponseWriter, *http.Request) {
 		case "close":
 			closeHandler.ServeHTTP(w, r)
 		case "cancel":
-			w.WriteHeader(http.StatusNotImplemented)
+			// w.WriteHeader(http.StatusNotImplemented)
+			cancelHandler.ServeHTTP(w, r)
 		case "resolve":
 			resolveHandler.ServeHTTP(w, r)
 		case "pause-notify":


### PR DESCRIPTION
### Description
Checks the status of an incident in the Hellper database before rendering the cancel dialog.

### How to test?
1. Change line `internal/handler/route.go:72` to `cancelHandler.ServeHTTP(w, r)`:
```go
case "cancel":
	cancelHandler.ServeHTTP(w, r)
```
2. Deploy this branch on staging or local environment
3. Open an incident
4. Call `/staging_hellper_cancel`
5. Resolve the incident
6. Call `/staging_hellper_cancel` again

### Expected behavior
1. On the first time the command is called, when the incident status is `open`, the cancel dialog should render properly with the field **Description**.
![image](https://user-images.githubusercontent.com/18470453/87694073-1919ce00-c764-11ea-87c7-c1923d684086.png)

2. On the second time, after the resolve command, so when the incident status is `resolved`, the cancel dialog should not appear, but instead an ephemeral message for the user.
![image](https://user-images.githubusercontent.com/18470453/87694092-20d97280-c764-11ea-8bbd-bb66591c234c.png)
