### PR TITLE
add verification on cancel notify and fix the pin message

### DIFF
--- a/internal/commands/cancel.go
+++ b/internal/commands/cancel.go
@@ -101,6 +101,12 @@ func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.L
 		log.NewValue("incident_cancel_details", incidentDetails),
 	)
 
+	var (
+		supportTeam      = config.Env.SupportTeam
+		notifyOnCancel   = config.Env.NotifyOnCancel
+		productChannelID = config.Env.ProductChannelID
+	)
+
 	incidentAuthor := incidentDetails.User.ID
 	channelID := incidentDetails.Channel.ID
 	submission := incidentDetails.Submission
@@ -129,7 +135,7 @@ func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.L
 		},
 	}
 
-	message := "An Incident has been canceled by <@" + incidentAuthor + "> *cc:* <" + config.Env.SupportTeam + ">"
+	message := "An Incident has been canceled by <@" + incidentAuthor + "> *cc:* <!subteam^" + supportTeam + ">"
 
 	postAndPinMessage(
 		client,
@@ -137,12 +143,15 @@ func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.L
 		message,
 		attachment,
 	)
-	postAndPinMessage(
-		client,
-		config.Env.ProductChannelID,
-		message,
-		attachment,
-	)
+	if notifyOnCancel {
+		postAndPinMessage(
+			client,
+			productChannelID,
+			message,
+			attachment,
+		)
+	}
+
 	repository.CancelIncident(ctx, channelID, description)
 	client.ArchiveConversationContext(ctx, channelID)
 


### PR DESCRIPTION
### Description
This PR implements the verification that allows the user to notify or not the channel #incidentes-produto when an incident is being canceled. 
Also, it fixes the message pinned when the incident is canceled. Before this PR the team was not being printed correctly.


### How to test?
There are two possible tests. 
### 1. Test.
1. In the Staging environment set the environment variable **HELLPER_NOTIFY_ON_CANCEL** to **false**.
![image](https://user-images.githubusercontent.com/44374637/88296805-86ce7880-ccd5-11ea-8708-3f2981cff0c8.png)

2. Open an Incident
3. Cancel the Incident.

### Expected behavior
In this case, only the incident channel should be notified about the canceling.
The message displayed should show the description and the team that was supporting the incident. 
![image](https://user-images.githubusercontent.com/44374637/88297075-de6ce400-ccd5-11ea-9f6a-f3c81f34d294.png)
 
### 2. Test.
1. In the Staging environment set the environment variable **HELLPER_NOTIFY_ON_CANCEL** to **true**.
![image](https://user-images.githubusercontent.com/44374637/88297337-2b50ba80-ccd6-11ea-96bf-46d21f686251.png)
2. Open an Incident
3. Cancel the Incident.

### Expected behavior
In this case, the incident channel and the channel #staging-hellper should be notified about the canceling.
The message displayed in both channels should show the description and the team that was supporting the incident. 
![image](https://user-images.githubusercontent.com/44374637/88297075-de6ce400-ccd5-11ea-9f6a-f3c81f34d294.png)
