### PR TITLE
Hydra add incident id to comms

### DIFF
--- a/internal/commands/cancel.go
+++ b/internal/commands/cancel.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"strconv"
 	"strings"
 
 	"hellper/internal/bot"
@@ -95,7 +94,7 @@ func OpenCancelIncidentDialog(
 }
 
 // CancelIncidentByDialog cancels an incident after receiving data from a Slack dialog
-func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.Logger, repository model.Repository, incidentDetails bot.DialogSubmission, incident model.Incident, IncidentID int64) error {
+func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.Logger, repository model.Repository, incidentDetails bot.DialogSubmission) error {
 	logger.Info(
 		ctx,
 		"command/cancel.CancelIncidentByDialog",
@@ -125,10 +124,6 @@ func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.L
 		Text:     "",
 		Color:    "#EDA248",
 		Fields: []slack.AttachmentField{
-			{
-				Title: "Incident ID",
-				Value: strconv.FormatInt(IncidentID, 10),
-			},
 			{
 				Title: "Channel",
 				Value: "<#" + channelID + ">",
@@ -161,14 +156,4 @@ func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.L
 	client.ArchiveConversationContext(ctx, channelID)
 
 	return nil
-}
-
-inc, err := repository.GetIncident(ctx, channelID)
-if err != nil {
-	logger.Error(
-		ctx,
-		"command/resolve.getCalendarEvent repository.get_incident error",
-		log.NewValue("error", err),
-	)
-	return err
 }

--- a/internal/commands/cancel.go
+++ b/internal/commands/cancel.go
@@ -142,7 +142,7 @@ func CancelIncidentByDialog(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("CancelIncidentByDialog GetIncident"),
+			log.Reason("GetIncident"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
@@ -210,12 +210,12 @@ func CancelIncidentByDialog(
 	return nil
 }
 
-func createCancelAttachment(inc model.Incident, incidentID int64, channelID, userID, description string) slack.Attachment {
+func createCancelAttachment(inc model.Incident, userID string) slack.Attachment {
 	var messageText strings.Builder
 
 	messageText.WriteString("An Incident has been canceled by <@" + userID + ">\n\n")
-	messageText.WriteString("*Channel:* <#" + channelID + ">\n")
-	messageText.WriteString("*Description:* `" + description + "`\n\n")
+	messageText.WriteString("*Channel:* <#" + inc.ChannelId + ">\n")
+	messageText.WriteString("*Description:* `" + inc.DescriptionCancelled + "`\n\n")
 
 	return slack.Attachment{
 		Pretext:  "",
@@ -225,15 +225,15 @@ func createCancelAttachment(inc model.Incident, incidentID int64, channelID, use
 		Fields: []slack.AttachmentField{
 			{
 				Title: "Incident ID",
-				Value: strconv.FormatInt(incidentID, 10),
+				Value: strconv.FormatInt(inc.Id, 10),
 			},
 			{
 				Title: "Channel",
-				Value: "<#" + channelID + ">",
+				Value: "<#" + inc.ChannelId + ">",
 			},
 			{
 				Title: "Description",
-				Value: "```" + description + "```",
+				Value: "```" + inc.DescriptionCancelled + "```",
 			},
 		},
 	}

--- a/internal/commands/cancel.go
+++ b/internal/commands/cancel.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	"hellper/internal/bot"
@@ -94,7 +95,7 @@ func OpenCancelIncidentDialog(
 }
 
 // CancelIncidentByDialog cancels an incident after receiving data from a Slack dialog
-func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.Logger, repository model.Repository, incidentDetails bot.DialogSubmission) error {
+func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.Logger, repository model.Repository, incidentDetails bot.DialogSubmission, incident model.Incident, IncidentID int64) error {
 	logger.Info(
 		ctx,
 		"command/cancel.CancelIncidentByDialog",
@@ -124,11 +125,15 @@ func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.L
 		Text:     "",
 		Color:    "#EDA248",
 		Fields: []slack.AttachmentField{
-			slack.AttachmentField{
+			{
+				Title: "Incident ID",
+				Value: strconv.FormatInt(IncidentID, 10),
+			},
+			{
 				Title: "Channel",
 				Value: "<#" + channelID + ">",
 			},
-			slack.AttachmentField{
+			{
 				Title: "Description",
 				Value: "```" + description + "```",
 			},
@@ -156,4 +161,14 @@ func CancelIncidentByDialog(ctx context.Context, client bot.Client, logger log.L
 	client.ArchiveConversationContext(ctx, channelID)
 
 	return nil
+}
+
+inc, err := repository.GetIncident(ctx, channelID)
+if err != nil {
+	logger.Error(
+		ctx,
+		"command/resolve.getCalendarEvent repository.get_incident error",
+		log.NewValue("error", err),
+	)
+	return err
 }

--- a/internal/commands/cancel.go
+++ b/internal/commands/cancel.go
@@ -149,7 +149,7 @@ func CancelIncidentByDialog(
 		return err
 	}
 
-	attachment := createCancelAttachment(inc, inc.Id, channelID, userID, description)
+	attachment := createCancelAttachment(inc, userID)
 	message := "An Incident has been canceled by <@" + userID + "> *cc:* <!subteam^" + supportTeam + ">"
 
 	err = postAndPinMessage(

--- a/internal/commands/cancel_test.go
+++ b/internal/commands/cancel_test.go
@@ -94,7 +94,7 @@ func (f *cancelCommandFixture) setup(t *testing.T) {
 	f.mockRepository = repositoryMock
 
 }
-func TestOpenCancelIncidentDiolog(t *testing.T) {
+func TestOpenCancelIncidentDialog(t *testing.T) {
 	table := []cancelCommandFixture{
 		{
 			testName:     "Check error if incident is not open",

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -254,7 +254,7 @@ func getResponsabilityText(r string) string {
 	return ""
 }
 
-func createCloseChannelAttachment(inc model.Incident, incidentID int64, userName, impact string) slack.Attachment {
+func createCloseChannelAttachment(inc model.Incident, IncidentID, userName, impact string) slack.Attachment {
 	var messageText strings.Builder
 	messageText.WriteString("The Incident <#" + inc.ChannelId + "> has been closed by <@" + userName + ">\n\n")
 	messageText.WriteString("*Team:* <#" + inc.Team + ">\n")
@@ -272,7 +272,7 @@ func createCloseChannelAttachment(inc model.Incident, incidentID int64, userName
 		Fields: []slack.AttachmentField{
 			{
 				Title: "Incident ID",
-				Value: strconv.FormatInt(incidentID, 10),
+				Value: strconv.FormatInt(inc.Id, 10),
 			},
 			{
 				Title: "Incident",
@@ -318,7 +318,7 @@ func createClosePrivateAttachment(inc model.Incident) slack.Attachment {
 		Color:    "#FE4D4D",
 		Fields: []slack.AttachmentField{
 			slack.AttachmentField{
-				Title: "Statu.io",
+				Title: "Status.io",
 				Value: "Be sure to close the incident on status.io",
 			},
 		},

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"hellper/internal/concurrence"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -253,7 +254,7 @@ func getResponsabilityText(r string) string {
 	return ""
 }
 
-func createCloseChannelAttachment(inc model.Incident, userName, impact string) slack.Attachment {
+func createCloseChannelAttachment(inc model.Incident, incidentID int64, userName, impact string) slack.Attachment {
 	var messageText strings.Builder
 	messageText.WriteString("The Incident <#" + inc.ChannelId + "> has been closed by <@" + userName + ">\n\n")
 	messageText.WriteString("*Team:* <#" + inc.Team + ">\n")
@@ -269,31 +270,35 @@ func createCloseChannelAttachment(inc model.Incident, userName, impact string) s
 		Text:     "",
 		Color:    "#6fff47",
 		Fields: []slack.AttachmentField{
-			slack.AttachmentField{
+			{
+				Title: "Incident ID",
+				Value: strconv.FormatInt(incidentID, 10),
+			},
+			{
 				Title: "Incident",
 				Value: "<#" + inc.ChannelId + ">",
 			},
-			slack.AttachmentField{
+			{
 				Title: "Team",
 				Value: inc.Team,
 			},
-			slack.AttachmentField{
+			{
 				Title: "Feature",
 				Value: inc.Functionality,
 			},
-			slack.AttachmentField{
+			{
 				Title: "Impact",
 				Value: impact,
 			},
-			slack.AttachmentField{
+			{
 				Title: "Severity",
 				Value: getSeverityLevelText(inc.SeverityLevel),
 			},
-			slack.AttachmentField{
+			{
 				Title: "Responsibility",
 				Value: inc.Responsibility,
 			},
-			slack.AttachmentField{
+			{
 				Title: "RootCause",
 				Value: inc.RootCause,
 			},

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -22,7 +22,7 @@ func CloseIncidentDialog(ctx context.Context, logger log.Logger, client bot.Clie
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("CloseIncidentDialog GetIncident"),
+			log.Reason("GetIncident"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
@@ -205,7 +205,7 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("CloseIncidentByDialog CloseIncident"),
+			log.Reason("CloseIncident"),
 			log.NewValue("incident", incident),
 			log.NewValue("error", err),
 		)
@@ -217,16 +217,16 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("CloseIncidentByDialog GetIncident"),
+			log.Reason("GetIncident"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
 		return err
 	}
 
-	channelAttachment := createCloseChannelAttachment(incident, inc.Id, userName, impact)
+	channelAttachment := createCloseChannelAttachment(inc, userName, impact)
 	privateAttachment := createClosePrivateAttachment(incident)
-	message := "The Incident <#" + incident.ChannelId + "> has been closed by <@" + userName + ">"
+	message := "The Incident <#" + inc.ChannelId + "> has been closed by <@" + userName + ">"
 
 	var waitgroup sync.WaitGroup
 	defer waitgroup.Wait()
@@ -256,7 +256,7 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("CloseIncidentByDialog ArchiveConversationContext"),
+			log.Reason("ArchiveConversationContext"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("userID", userID),
 			log.NewValue("error", err),
@@ -278,7 +278,7 @@ func getResponsabilityText(r string) string {
 	return ""
 }
 
-func createCloseChannelAttachment(inc model.Incident, incidentID int64, userName, impact string) slack.Attachment {
+func createCloseChannelAttachment(inc model.Incident, userName, impact string) slack.Attachment {
 	var messageText strings.Builder
 	messageText.WriteString("The Incident <#" + inc.ChannelId + "> has been closed by <@" + userName + ">\n\n")
 	messageText.WriteString("*Team:* <#" + inc.Team + ">\n")
@@ -296,7 +296,7 @@ func createCloseChannelAttachment(inc model.Incident, incidentID int64, userName
 		Fields: []slack.AttachmentField{
 			{
 				Title: "Incident ID",
-				Value: strconv.FormatInt(incidentID, 10),
+				Value: strconv.FormatInt(inc.Id, 10),
 			},
 			{
 				Title: "Incident",

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -26,7 +26,6 @@ func CloseIncidentDialog(ctx context.Context, logger log.Logger, client bot.Clie
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
-		return err
 
 		PostErrorAttachment(ctx, client, logger, channelID, userID, err.Error())
 		return err
@@ -341,7 +340,7 @@ func createClosePrivateAttachment(inc model.Incident) slack.Attachment {
 		Text:     "",
 		Color:    "#FE4D4D",
 		Fields: []slack.AttachmentField{
-			slack.AttachmentField{
+			{
 				Title: "Status.io",
 				Value: "Be sure to close the incident on status.io",
 			},

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -225,7 +225,7 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 	}
 
 	channelAttachment := createCloseChannelAttachment(inc, userName, impact)
-	privateAttachment := createClosePrivateAttachment(incident)
+	privateAttachment := createClosePrivateAttachment(inc)
 	message := "The Incident <#" + inc.ChannelId + "> has been closed by <@" + userName + ">"
 
 	var waitgroup sync.WaitGroup

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"hellper/internal/concurrence"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -254,7 +253,7 @@ func getResponsabilityText(r string) string {
 	return ""
 }
 
-func createCloseChannelAttachment(inc model.Incident, IncidentID, userName, impact string) slack.Attachment {
+func createCloseChannelAttachment(inc model.Incident, userName, impact string) slack.Attachment {
 	var messageText strings.Builder
 	messageText.WriteString("The Incident <#" + inc.ChannelId + "> has been closed by <@" + userName + ">\n\n")
 	messageText.WriteString("*Team:* <#" + inc.Team + ">\n")
@@ -270,10 +269,6 @@ func createCloseChannelAttachment(inc model.Incident, IncidentID, userName, impa
 		Text:     "",
 		Color:    "#6fff47",
 		Fields: []slack.AttachmentField{
-			{
-				Title: "Incident ID",
-				Value: strconv.FormatInt(inc.Id, 10),
-			},
 			{
 				Title: "Incident",
 				Value: "<#" + inc.ChannelId + ">",
@@ -318,7 +313,7 @@ func createClosePrivateAttachment(inc model.Incident) slack.Attachment {
 		Color:    "#FE4D4D",
 		Fields: []slack.AttachmentField{
 			slack.AttachmentField{
-				Title: "Status.io",
+				Title: "Statu.io",
 				Value: "Be sure to close the incident on status.io",
 			},
 		},

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -22,7 +22,7 @@ func CloseIncidentDialog(ctx context.Context, logger log.Logger, client bot.Clie
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("GetIncident"),
+			log.Reason("CloseIncidentDialog GetIncident"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
@@ -205,7 +205,7 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("CloseIncident"),
+			log.Reason("CloseIncidentByDialog CloseIncident"),
 			log.NewValue("incident", incident),
 			log.NewValue("error", err),
 		)
@@ -217,7 +217,7 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("GetIncident"),
+			log.Reason("CloseIncidentByDialog GetIncident"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
@@ -255,7 +255,8 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/close.CloseIncidentByDialog ArchiveConversationContext ERROR",
+			log.Trace(),
+			log.Reason("CloseIncidentByDialog ArchiveConversationContext"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("userID", userID),
 			log.NewValue("error", err),

--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -21,10 +21,12 @@ func CloseIncidentDialog(ctx context.Context, logger log.Logger, client bot.Clie
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/dates.UpdateDatesDialog GetIncident ERROR",
+			log.Trace(),
+			log.Reason("GetIncident"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
+		return err
 
 		PostErrorAttachment(ctx, client, logger, channelID, userID, err.Error())
 		return err
@@ -199,6 +201,30 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 		ChannelId:      channelID,
 	}
 
+	err = repository.CloseIncident(ctx, &incident)
+	if err != nil {
+		logger.Error(
+			ctx,
+			log.Trace(),
+			log.Reason("CloseIncident"),
+			log.NewValue("incident", incident),
+			log.NewValue("error", err),
+		)
+		return err
+	}
+
+	inc, err := repository.GetIncident(ctx, channelID)
+	if err != nil {
+		logger.Error(
+			ctx,
+			log.Trace(),
+			log.Reason("GetIncident"),
+			log.NewValue("channelID", channelID),
+			log.NewValue("error", err),
+		)
+		return err
+	}
+
 	channelAttachment := createCloseChannelAttachment(incident, inc.Id, userName, impact)
 	privateAttachment := createClosePrivateAttachment(incident)
 	message := "The Incident <#" + incident.ChannelId + "> has been closed by <@" + userName + ">"
@@ -239,19 +265,7 @@ func CloseIncidentByDialog(ctx context.Context, client bot.Client, logger log.Lo
 		return err
 	}
 
-	repository.CloseIncident(ctx, &incident)
-
 	return nil
-}
-
-inc, err := repository.GetIncident(ctx, channelID)
-if err != nil {
-	logger.Error(
-		ctx,
-		"command/resolve.getCalendarEvent repository.get_incident error",
-		log.NewValue("error", err),
-	)
-	return err
 }
 
 func getResponsabilityText(r string) string {

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -228,7 +228,7 @@ func StartIncidentByDialog(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("StartIncidentByDialog JoinConversationContext"),
+			log.Reason("JoinConversationContext"),
 			log.NewValue("warning", warning),
 			log.NewValue("meta_warning", metaWarning),
 			log.NewValue("error", err),
@@ -241,7 +241,7 @@ func StartIncidentByDialog(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("StartIncidentByDialog InviteUsersToConversationContext"),
+			log.Reason("InviteUsersToConversationContext"),
 			log.NewValue("channel.ID", channel.ID),
 			log.NewValue("commander", commander),
 			log.NewValue("error", err),
@@ -258,7 +258,7 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("createPostMortemAndUpdateTopic createPostMortem"),
+			log.Reason("createPostMortem"),
 			log.NewValue("channel.Name", channel.Name),
 			log.NewValue("error", err),
 		)
@@ -275,7 +275,7 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("createPostMortemAndUpdateTopic SetTopicOfConversation"),
+			log.Reason("SetTopicOfConversation"),
 			log.NewValue("channel.ID", channel.ID),
 			log.NewValue("topic.String", topic.String()),
 			log.NewValue("error", err),

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -205,7 +205,7 @@ func StartIncidentByDialog(
 		}
 	}
 
-	attachment := createOpenAttachment(incident, warRoomURL, supportTeam)
+	attachment := createOpenAttachment(incident, incidentID, warRoomURL, supportTeam)
 	message := "An Incident has been opened by <@" + incident.IncidentAuthor + ">"
 
 	var waitgroup sync.WaitGroup
@@ -283,7 +283,7 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 	}
 }
 
-func createOpenAttachment(incident model.Incident, warRoomURL string, supportTeam string) slack.Attachment {
+func createOpenAttachment(incident model.Incident, incidentID int64, warRoomURL string, supportTeam string) slack.Attachment {
 	var messageText strings.Builder
 	messageText.WriteString("An Incident has been opened by <@" + incident.IncidentAuthor + ">\n\n")
 	messageText.WriteString("*Severity:* " + getSeverityLevelText(incident.SeverityLevel) + "\n\n")
@@ -302,7 +302,7 @@ func createOpenAttachment(incident model.Incident, warRoomURL string, supportTea
 		Fields: []slack.AttachmentField{
 			{
 				Title: "Incident ID",
-				Value: strconv.FormatInt(incident.Id, 10),
+				Value: strconv.FormatInt(incidentID, 10),
 			},
 			{
 				Title: "Severity",

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -293,6 +293,10 @@ func createOpenAttachment(incident model.Incident, incidentID int64, warRoomURL 
 		Color:    "#FE4D4D",
 		Fields: []slack.AttachmentField{
 			{
+				Title: "Incident ID",
+				Value: strconv.FormatInt(incidentID, 10),
+			},
+			{
 				Title: "Severity",
 				Value: getSeverityLevelText(incident.SeverityLevel),
 			},
@@ -315,10 +319,6 @@ func createOpenAttachment(incident model.Incident, incidentID int64, warRoomURL 
 			{
 				Title: "War Room",
 				Value: warRoomURL,
-			},
-			{
-				Title: "Incident ID",
-				Value: strconv.FormatInt(incidentID, 10),
 			},
 		},
 	}

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -205,7 +205,7 @@ func StartIncidentByDialog(
 		}
 	}
 
-	attachment := createOpenAttachment(incident, incidentID, warRoomURL, supportTeam)
+	attachment := createOpenAttachment(incident, warRoomURL, supportTeam)
 	message := "An Incident has been opened by <@" + incident.IncidentAuthor + ">"
 
 	var waitgroup sync.WaitGroup
@@ -283,7 +283,7 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 	}
 }
 
-func createOpenAttachment(incident model.Incident, incidentID int64, warRoomURL string, supportTeam string) slack.Attachment {
+func createOpenAttachment(incident model.Incident, warRoomURL string, supportTeam string) slack.Attachment {
 	var messageText strings.Builder
 	messageText.WriteString("An Incident has been opened by <@" + incident.IncidentAuthor + ">\n\n")
 	messageText.WriteString("*Severity:* " + getSeverityLevelText(incident.SeverityLevel) + "\n\n")
@@ -302,7 +302,7 @@ func createOpenAttachment(incident model.Incident, incidentID int64, warRoomURL 
 		Fields: []slack.AttachmentField{
 			{
 				Title: "Incident ID",
-				Value: strconv.FormatInt(incidentID, 10),
+				Value: strconv.FormatInt(incident.Id, 10),
 			},
 			{
 				Title: "Severity",

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -227,7 +227,8 @@ func StartIncidentByDialog(
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/open.join_channel_error",
+			log.Trace(),
+			log.Reason("StartIncidentByDialog JoinConversationContext"),
 			log.NewValue("warning", warning),
 			log.NewValue("meta_warning", metaWarning),
 			log.NewValue("error", err),
@@ -239,7 +240,10 @@ func StartIncidentByDialog(
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/open.invite_commander_error",
+			log.Trace(),
+			log.Reason("StartIncidentByDialog InviteUsersToConversationContext"),
+			log.NewValue("channel.ID", channel.ID),
+			log.NewValue("commander", commander),
 			log.NewValue("error", err),
 		)
 		return err
@@ -253,8 +257,9 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/open.create_post_mortem ERROR",
-			log.NewValue("channel_name", channel.Name),
+			log.Trace(),
+			log.Reason("createPostMortemAndUpdateTopic createPostMortem"),
+			log.NewValue("channel.Name", channel.Name),
 			log.NewValue("error", err),
 		)
 		return
@@ -269,7 +274,10 @@ func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, clie
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/open.set_channel_topic_error",
+			log.Trace(),
+			log.Reason("createPostMortemAndUpdateTopic SetTopicOfConversation"),
+			log.NewValue("channel.ID", channel.ID),
+			log.NewValue("topic.String", topic.String()),
 			log.NewValue("error", err),
 		)
 	}

--- a/internal/commands/postmortem.go
+++ b/internal/commands/postmortem.go
@@ -48,7 +48,7 @@ func createPostMortem(
 		Text:     "",
 		Color:    "#FE4D4D",
 		Fields: []slack.AttachmentField{
-			slack.AttachmentField{
+			{
 				Title: "Post Mortem",
 				Value: postMortemURL,
 			},

--- a/internal/commands/resolve.go
+++ b/internal/commands/resolve.go
@@ -122,7 +122,7 @@ func ResolveIncidentByDialog(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("ResolveIncidentByDialog ResolveIncident"),
+			log.Reason("ResolveIncident"),
 			log.NewValue("incident", incident),
 			log.NewValue("error", err),
 		)
@@ -134,7 +134,7 @@ func ResolveIncidentByDialog(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("ResolveIncidentByDialog GetIncident"),
+			log.Reason("GetIncident"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
@@ -146,7 +146,7 @@ func ResolveIncidentByDialog(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("ResolveIncidentByDialog strconv.ParseBool"),
+			log.Reason("strconv.ParseBool"),
 			log.NewValue("error", err),
 		)
 		return err
@@ -158,14 +158,14 @@ func ResolveIncidentByDialog(
 			logger.Error(
 				ctx,
 				log.Trace(),
-				log.Reason("ResolveIncidentByDialog getCalendarEvent"),
+				log.Reason("getCalendarEvent"),
 				log.NewValue("error", err),
 			)
 			return err
 		}
 	}
 
-	channelAttachment := createResolveChannelAttachment(incident, inc.Id, userName, calendarEvent)
+	channelAttachment := createResolveChannelAttachment(inc, userName, calendarEvent)
 	privateAttachment := createResolvePrivateAttachment(incident, calendarEvent)
 	message := "The Incident <#" + incident.ChannelId + "> has been resolved by <@" + userName + ">"
 
@@ -212,7 +212,7 @@ func setMeetingDate(ctx context.Context, logger log.Logger, d *time.Time, postMo
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("setMeetingDate LoadLocation"),
+			log.Reason("time.LoadLocation"),
 			log.NewValue("timezone", timezone),
 			log.NewValue("error", err),
 		)
@@ -242,7 +242,7 @@ func getCalendarEvent(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("getCalendarEvent setMeetingDate"),
+			log.Reason("setMeetingDate"),
 			log.NewValue("error", err),
 		)
 		return nil, err
@@ -256,7 +256,7 @@ func getCalendarEvent(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("getCalendarEvent GetIncident"),
+			log.Reason("GetIncident"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
@@ -268,7 +268,7 @@ func getCalendarEvent(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("getCalendarEvent CreateCalendarEvent"),
+			log.Reason("CreateCalendarEvent"),
 			log.NewValue("error", err),
 		)
 		return nil, err
@@ -276,7 +276,7 @@ func getCalendarEvent(
 	return calendarEvent, err
 }
 
-func createResolveChannelAttachment(inc model.Incident, incidentID int64, userName string, event *model.Event) slack.Attachment {
+func createResolveChannelAttachment(inc model.Incident, userName string, event *model.Event) slack.Attachment {
 	var (
 		endDateText       = inc.EndTimestamp.Format(time.RFC1123)
 		postMortemMessage string
@@ -303,7 +303,7 @@ func createResolveChannelAttachment(inc model.Incident, incidentID int64, userNa
 		Fields: []slack.AttachmentField{
 			{
 				Title: "Incident ID",
-				Value: strconv.FormatInt(incidentID, 10),
+				Value: strconv.FormatInt(inc.Id, 10),
 			},
 			{
 				Title: "Incident",

--- a/internal/commands/resolve.go
+++ b/internal/commands/resolve.go
@@ -127,6 +127,16 @@ func ResolveIncidentByDialog(
 		return err
 	}
 
+	inc, err := repository.GetIncident(ctx, channelID)
+	if err != nil {
+		logger.Error(
+			ctx,
+			"command/resolve.getCalendarEvent repository.get_incident error",
+			log.NewValue("error", err),
+		)
+		return err
+	}
+
 	hasPostMortemMeeting, err := strconv.ParseBool(postMortemMeeting)
 	if err != nil {
 		logger.Error(
@@ -149,7 +159,7 @@ func ResolveIncidentByDialog(
 		}
 	}
 
-	channelAttachment := createResolveChannelAttachment(incident, userName, calendarEvent)
+	channelAttachment := createResolveChannelAttachment(incident, inc.Id, userName, calendarEvent)
 	privateAttachment := createResolvePrivateAttachment(incident, calendarEvent)
 	message := "The Incident <#" + incident.ChannelId + "> has been resolved by <@" + userName + ">"
 

--- a/internal/commands/resolve.go
+++ b/internal/commands/resolve.go
@@ -254,7 +254,7 @@ func getCalendarEvent(
 	return calendarEvent, err
 }
 
-func createResolveChannelAttachment(inc model.Incident, userName string, event *model.Event) slack.Attachment {
+func createResolveChannelAttachment(inc model.Incident, incidentID int64, userName string, event *model.Event) slack.Attachment {
 	var (
 		endDateText       = inc.EndTimestamp.Format(time.RFC1123)
 		postMortemMessage string
@@ -279,6 +279,10 @@ func createResolveChannelAttachment(inc model.Incident, userName string, event *
 		Text:     "",
 		Color:    "#1164A3",
 		Fields: []slack.AttachmentField{
+			{
+				Title: "Incident ID",
+				Value: strconv.FormatInt(incidentID, 10),
+			},
 			{
 				Title: "Incident",
 				Value: "<#" + inc.ChannelId + ">",

--- a/internal/commands/resolve.go
+++ b/internal/commands/resolve.go
@@ -121,7 +121,9 @@ func ResolveIncidentByDialog(
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/resolve.ResolveIncidentByDialog repository.resolve_incident error",
+			log.Trace(),
+			log.Reason("ResolveIncident"),
+			log.NewValue("incident", incident),
 			log.NewValue("error", err),
 		)
 		return err
@@ -131,7 +133,9 @@ func ResolveIncidentByDialog(
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/resolve.getCalendarEvent repository.get_incident error",
+			log.Trace(),
+			log.Reason("GetIncident"),
+			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
 		return err
@@ -246,7 +250,9 @@ func getCalendarEvent(
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/resolve.getCalendarEvent repository.get_incident error",
+			log.Trace(),
+			log.Reason("GetIncident"),
+			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
 		return nil, err

--- a/internal/commands/resolve.go
+++ b/internal/commands/resolve.go
@@ -122,7 +122,7 @@ func ResolveIncidentByDialog(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("ResolveIncident"),
+			log.Reason("ResolveIncidentByDialog ResolveIncident"),
 			log.NewValue("incident", incident),
 			log.NewValue("error", err),
 		)
@@ -134,7 +134,7 @@ func ResolveIncidentByDialog(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("GetIncident"),
+			log.Reason("ResolveIncidentByDialog GetIncident"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
@@ -145,7 +145,8 @@ func ResolveIncidentByDialog(
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/resolve.ResolveIncidentByDialog strconv.parse_bool error",
+			log.Trace(),
+			log.Reason("ResolveIncidentByDialog strconv.ParseBool"),
 			log.NewValue("error", err),
 		)
 		return err
@@ -156,7 +157,8 @@ func ResolveIncidentByDialog(
 		if err != nil {
 			logger.Error(
 				ctx,
-				"command/resolve.ResolveIncidentByDialog get_calendar_event error",
+				log.Trace(),
+				log.Reason("ResolveIncidentByDialog getCalendarEvent"),
 				log.NewValue("error", err),
 			)
 			return err
@@ -209,7 +211,9 @@ func setMeetingDate(ctx context.Context, logger log.Logger, d *time.Time, postMo
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/resolve.setMeetingDate time.load_location error",
+			log.Trace(),
+			log.Reason("setMeetingDate LoadLocation"),
+			log.NewValue("timezone", timezone),
 			log.NewValue("error", err),
 		)
 		return "", "", err
@@ -237,7 +241,8 @@ func getCalendarEvent(
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/resolve.getCalendarEvent set_meeting_date error",
+			log.Trace(),
+			log.Reason("getCalendarEvent setMeetingDate"),
 			log.NewValue("error", err),
 		)
 		return nil, err
@@ -251,7 +256,7 @@ func getCalendarEvent(
 		logger.Error(
 			ctx,
 			log.Trace(),
-			log.Reason("GetIncident"),
+			log.Reason("getCalendarEvent GetIncident"),
 			log.NewValue("channelID", channelID),
 			log.NewValue("error", err),
 		)
@@ -262,7 +267,8 @@ func getCalendarEvent(
 	if err != nil {
 		logger.Error(
 			ctx,
-			"command/resolve.getCalendarEvent calendar.create_calendar_event error",
+			log.Trace(),
+			log.Reason("getCalendarEvent CreateCalendarEvent"),
 			log.NewValue("error", err),
 		)
 		return nil, err

--- a/internal/commands/resolve_test.go
+++ b/internal/commands/resolve_test.go
@@ -156,12 +156,14 @@ func TestResolveIncidentByDialog(t *testing.T) {
 			incidentDetails: buildSubmissionMock("true"),
 			channelID:       "CT50JJGP5",
 			mockEvent:       buildEventMock(),
+			mockIncident:    buildResolveIncidentMock(),
 		},
 		{
 			testName:        "Incident Resolved without PM Meeting",
 			expectError:     false,
 			incidentDetails: buildSubmissionMock("false"),
 			channelID:       "CT50JJGP5",
+			mockIncident:    buildResolveIncidentMock(),
 		},
 		{
 			testName:        "Incident Resolved without PM conditional",
@@ -170,6 +172,7 @@ func TestResolveIncidentByDialog(t *testing.T) {
 			incidentDetails: buildSubmissionMock(""),
 			channelID:       "CT50JJGP5",
 			mockEvent:       buildEventMock(),
+			mockIncident:    buildResolveIncidentMock(),
 		},
 	}
 
@@ -198,7 +201,7 @@ func TestResolveIncidentByDialog(t *testing.T) {
 	}
 }
 
-func buildResolveIncidentMock(status string) model.Incident {
+func buildResolveIncidentMock() model.Incident {
 	var (
 		startDate          = time.Date(2020, time.March, 19, 12, 00, 00, 00, time.UTC)
 		identificationDate = time.Date(2020, time.March, 19, 14, 20, 00, 00, time.UTC)
@@ -218,7 +221,7 @@ func buildResolveIncidentMock(status string) model.Incident {
 		CustomerImpact:          2300,
 		StatusPageUrl:           "status.io",
 		PostMortemUrl:           "google.com",
-		Status:                  status,
+		Status:                  "open",
 		Product:                 "RDSM",
 		SeverityLevel:           3,
 		ChannelName:             "inc-dates-command",

--- a/internal/commands/resolve_test.go
+++ b/internal/commands/resolve_test.go
@@ -198,6 +198,38 @@ func TestResolveIncidentByDialog(t *testing.T) {
 	}
 }
 
+func buildResolveIncidentMock(status string) model.Incident {
+	var (
+		startDate          = time.Date(2020, time.March, 19, 12, 00, 00, 00, time.UTC)
+		identificationDate = time.Date(2020, time.March, 19, 14, 20, 00, 00, time.UTC)
+		endDate            = time.Date(2020, time.March, 19, 22, 30, 00, 00, time.UTC)
+	)
+
+	return model.Incident{
+		Id:                      0,
+		Title:                   "Incident Dates Command",
+		StartTimestamp:          &startDate,
+		IdentificationTimestamp: &identificationDate,
+		EndTimestamp:            &endDate,
+		Responsibility:          "Product",
+		Team:                    "shield",
+		Functionality:           "hellper",
+		RootCause:               "PR #00",
+		CustomerImpact:          2300,
+		StatusPageUrl:           "status.io",
+		PostMortemUrl:           "google.com",
+		Status:                  status,
+		Product:                 "RDSM",
+		SeverityLevel:           3,
+		ChannelName:             "inc-dates-command",
+		UpdatedAt:               &endDate,
+		DescriptionStarted:      "An incident ocurred with the dates command",
+		DescriptionCancelled:    "",
+		DescriptionResolved:     "PR was reverted",
+		ChannelId:               "CT50JJGP5",
+	}
+}
+
 func buildEventMock() *model.Event {
 	var (
 		startDate = time.Date(2020, time.March, 19, 12, 00, 00, 00, time.UTC)

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -65,7 +65,7 @@ func PostErrorAttachment(ctx context.Context, client bot.Client, logger log.Logg
 		Text:     "",
 		Color:    "#FE4D4D",
 		Fields: []slack.AttachmentField{
-			slack.AttachmentField{
+			{
 				Title: "Error",
 				Value: text,
 			},
@@ -94,7 +94,7 @@ func PostInfoAttachment(ctx context.Context, client bot.Client, channelID string
 		Text:     "",
 		Color:    "#4DA6FE",
 		Fields: []slack.AttachmentField{
-			slack.AttachmentField{
+			{
 				Title: title,
 				Value: message,
 			},

--- a/internal/handler/cancel.go
+++ b/internal/handler/cancel.go
@@ -60,7 +60,8 @@ func (h *handlerCancel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Error(
 			ctx,
-			"handler/cancel.cancel_dialog_error",
+			log.Trace(),
+			log.Reason("commands.OpenCancelIncidentDialog"),
 			log.NewValue("error", err),
 		)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/handler/close.go
+++ b/internal/handler/close.go
@@ -66,7 +66,8 @@ func (h *handlerClose) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Error(
 			ctx,
-			"handler/close.ServeHTTP CloseIncidentDialog error",
+			log.Trace(),
+			log.Reason("commands.CloseIncidentDialog"),
 			log.NewValue("error", err),
 		)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/handler/open.go
+++ b/internal/handler/open.go
@@ -64,7 +64,9 @@ func (h *handlerOpen) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Error(
 			ctx,
-			"handler/open.ServeHTTP OpenStartIncidentDialog error",
+			log.Trace(),
+			log.Reason("OpenStartIncidentDialog"),
+			log.NewValue("triggerID", triggerID),
 			log.NewValue("error", err),
 		)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/handler/resolve.go
+++ b/internal/handler/resolve.go
@@ -64,7 +64,9 @@ func (h *handlerResolve) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Error(
 			ctx,
-			"handler/resolve.ServeHTTP ResolveIncidentDialog error",
+			log.Trace(),
+			log.Reason("ResolveIncidentDialog"),
+			log.NewValue("triggerID", triggerID),
 			log.NewValue("error", err),
 		)
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
### Description

This PR adds the IncidentID in every communication (Incident Open, Resolve, Close and Cancel Status).

Besides that, I've implemented better logs with Log.trace in some funcions.

### How to test?

Open an incident in Staging Env, and then, resolve, closed and cancel this incident.

### Expected behavior

In every status communication (Open, Resolve, Cancel and Close) the Incident ID should appear