### PR TITLE
Notify job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /hellperc
 /tmp
 /vendor
+/http
+/notify

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o /app/hellper /app/cmd/http
+RUN CGO_ENABLED=0 GOOS=linux go build -o . ./cmd/http ./cmd/notify
 
 FROM debian:buster
 RUN apt update -y && apt upgrade -y && apt install ca-certificates -y
-COPY --from=builder /app/hellper /app/hellper
+COPY --from=builder /app/entrypoint.sh /app/http /app/notify /app/
 EXPOSE 8080
 
-ENTRYPOINT ["/app/hellper"]
+RUN chmod +x /app/entrypoint.sh
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/cmd/notify/main.go
+++ b/cmd/notify/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"context"
+	"hellper/internal/notify"
+)
+
+func main() {
+	ctx := context.Background()
+	notify.Notify(ctx)
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ $# -eq 0 ]
+then
+  /app/http
+fi
+
+exec $@

--- a/internal/notify/channels-notify.go
+++ b/internal/notify/channels-notify.go
@@ -1,0 +1,58 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"hellper/internal"
+	"hellper/internal/log"
+)
+
+func channelsNotify(ctx context.Context) {
+
+	var (
+		to, msg string
+	)
+
+	logger.Info(ctx, log.Trace(), log.Action("running"))
+
+	if arg.statusFlag == "" {
+		logger.Error(ctx, log.Trace(), log.NewValue("error", errors.New("Must have a status")))
+		return
+	}
+
+	if arg.toFlag != "" {
+		logger.Error(ctx, log.Trace(), log.NewValue("error", errors.New("Forbidden to use the --to option with --type=channels")))
+		return
+	}
+
+	repository := internal.NewRepository(logger)
+
+	incidents, err := repository.ListActiveIncidents(ctx)
+	if err != nil {
+		logger.Error(ctx, log.Trace(), log.NewValue("error", err))
+	}
+
+	for _, incident := range incidents {
+
+		if arg.toFlag != "" {
+			to = arg.toFlag
+		} else {
+			to = incident.ChannelId
+		}
+
+		if arg.msgFlag != "" {
+			msg = arg.msgFlag
+		} else {
+			msg = statusNotify(incident)
+		}
+
+		if arg.statusFlag == incident.Status || arg.statusFlag == "all" {
+			logger.Info(ctx, log.Trace(), log.Action("notify_job"), log.NewValue("incident", incident))
+			err = send(to, msg)
+			if err != nil {
+				logger.Error(ctx, log.Trace(), log.NewValue("error", err))
+			}
+		}
+	}
+
+}

--- a/internal/notify/custom-notify.go
+++ b/internal/notify/custom-notify.go
@@ -1,0 +1,18 @@
+package notify
+
+import (
+	"context"
+	"hellper/internal/log"
+)
+
+func customNotify(ctx context.Context) {
+	logger.Info(ctx, log.Trace(), log.Action("running"))
+
+	err := send(arg.toFlag, arg.msgFlag)
+	if err != nil {
+		logger.Error(ctx, log.Trace(), log.NewValue("error", err))
+	}
+
+	logger.Info(ctx, log.Trace(), log.Action("done"))
+
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,85 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"hellper/internal"
+	"hellper/internal/config"
+	"hellper/internal/log"
+	"hellper/internal/model"
+
+	"github.com/slack-go/slack"
+)
+
+var (
+	logger = internal.NewLogger()
+	client = internal.NewClient(logger)
+
+	arg opt
+)
+
+type opt struct {
+	typeFlag   string
+	toFlag     string
+	msgFlag    string
+	statusFlag string
+}
+
+func init() {
+	var typeFlag, toFlag, msgFlag, statusFlag string
+	flag.StringVar(&typeFlag, "type", "", "[channels|report|custom]")
+	flag.StringVar(&toFlag, "to", "", "[channel id|user id]")
+	flag.StringVar(&msgFlag, "msg", "", "A text message")
+	flag.StringVar(&statusFlag, "status", "", "[all|open|resolved]")
+	flag.Parse()
+
+	arg = opt{typeFlag, toFlag, msgFlag, statusFlag}
+}
+
+// Notify is a CLI responsible for sending messages
+func Notify(ctx context.Context) {
+	logger.Info(ctx, log.Trace(), log.Action("running"))
+
+	switch arg.typeFlag {
+	case "channels":
+		channelsNotify(ctx)
+	case "report":
+		reportNotify(ctx)
+	case "custom":
+		customNotify(ctx)
+	default:
+		logger.Error(ctx, log.Trace(), log.NewValue("error", errors.New("Must have a type")))
+		return
+	}
+
+}
+
+func send(to, msg string) error {
+
+	if to == "" {
+		return errors.New("Must have a destination")
+	}
+
+	if msg == "" {
+		return errors.New("Must have a message")
+	}
+
+	_, _, err := client.PostMessage(to, slack.MsgOptionText(msg, false))
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func statusNotify(incident model.Incident) string {
+	switch incident.Status {
+	case model.StatusOpen:
+		return config.Env.ReminderOpenNotifyMsg
+	case model.StatusResolved:
+		return config.Env.ReminderResolvedNotifyMsg
+	}
+	return ""
+}

--- a/internal/notify/report-notify.go
+++ b/internal/notify/report-notify.go
@@ -1,0 +1,54 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"hellper/internal"
+	"hellper/internal/log"
+	"strings"
+)
+
+func reportNotify(ctx context.Context) {
+
+	logger.Info(ctx, log.Trace(), log.Action("running"))
+
+	if arg.statusFlag == "" {
+		logger.Error(ctx, log.Trace(), log.NewValue("error", errors.New("Must have a status")))
+		return
+	}
+
+	if arg.toFlag == "" {
+		logger.Error(ctx, log.Trace(), log.NewValue("error", errors.New("Must have a destination")))
+		return
+	}
+
+	if arg.msgFlag != "" {
+		logger.Error(ctx, log.Trace(), log.NewValue("error", errors.New("Forbidden to use the --msg option with --type=report")))
+		return
+	}
+
+	repository := internal.NewRepository(logger)
+
+	incidents, err := repository.ListActiveIncidents(ctx)
+	if err != nil {
+		logger.Error(ctx, log.Trace(), log.NewValue("error", err))
+	}
+
+	var notify strings.Builder
+	notify.WriteString(":mega: *Incident Reporting:*\n")
+
+	for _, incident := range incidents {
+		if arg.statusFlag == incident.Status || arg.statusFlag == "all" {
+			logger.Info(ctx, log.Trace(), log.Action("notify_job"), log.NewValue("incident", incident))
+			notify.WriteString("*<#" + incident.ChannelId + ">* - ")
+			notify.WriteString("Status: `" + incident.Status + "` - ")
+			notify.WriteString("Commander: <@" + incident.CommanderId + ">\n")
+		}
+	}
+
+	err = send(arg.toFlag, notify.String())
+	if err != nil {
+		logger.Error(ctx, log.Trace(), log.NewValue("error", err))
+	}
+
+}


### PR DESCRIPTION
# Description
<!--- Provide a minimal description of the changes or addition you are proposing in your pull request. -->
<!--- If it is related with a bug/issue fix, do not forget to link the issue in the description. -->
This PR is the basis for decoupling Goroutine to a k8s CronJob. This delivery allows us to make many configurations, such as, for example, notifying a slack channel, a person, generating a report and sending it by email in the future.

## What has been done?
* CLI notify

```
$ ./notify --help
Usage of ./notify:
  -msg string
    	A text message
  -status string
    	[all|open|resolved]
  -to string
    	[channel id|user id]
  -type string
    	[channels|report|custom]
```
* We can use it into CronJob service from k8s.

# How to test?
<!--- Provide a step by step to be followed that reproduce your feature/code changes to make the review easier. -->
## Build

```bash
git pull origin master
git checkout hydra-notify-cronjob-k8s
go build -o . ./cmd/notify
```

## Export the following environment variable:

```bash
export HELLPER_OAUTH_TOKEN=xoxb-.....
export HELLPER_DSN=postgres://.....
```

:warning: _* You can use the staging environment variables or from your development account._

## Send a custom message to any destination

This makes it possible to send private messages or to channels with a certain orientation.

```bash
./notify --type=custom --to=XXXXXX --msg="Hello, did you fill out the document?"
```


## Send a notification message to the respective channels

This is the default behavior that we will decouple, it notifies channels when the status of the incident is opened and/or resolved.

```bash
./notify -type=channels -status=all
./notify -type=channels -status=open
./notify -type=channels -status=resolved
```

## Send a incident report message to a destination

Service to send report to a specific destination.

```bash
./notify --type=report --to=XXXXXX --status=all
./notify --type=report --to=XXXXXX --status=open
./notify --type=report --to=XXXXXX --status=resolved
```


### Expected behavior
<!--- Provide a minimal description of what will be achieved with the PR -->
At this first moment, we do not have any changes in the application's behavior. With this code in production we will be able to use these commands.
