### PR TITLE
refactor: update open dialog to show title field on open incident

### DIFF
--- a/internal/bot/dialog_submission.go
+++ b/internal/bot/dialog_submission.go
@@ -29,6 +29,7 @@ type Channel struct {
 }
 
 type Submission struct {
+	IncidentTitle       string `json:"incident_title"`
 	ChannelName         string `json:"channel_name"`
 	WarRoomURL          string `json:"war_room_url"`
 	SeverityLevel       string `json:"severity_level"`

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -34,7 +34,7 @@ func OpenStartIncidentDialog(client bot.Client, triggerID string) error {
 			Label:       "Incident Title",
 			Name:        "incident_title",
 			Type:        "text",
-			Placeholder: "my-incident-title",
+			Placeholder: "My Incident Title",
 		},
 		MaxLength: 22,
 	}

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -265,7 +265,7 @@ func StartIncidentByDialog(
 }
 
 func createPostMortemAndUpdateTopic(ctx context.Context, logger log.Logger, client bot.Client, fileStorage filestorage.Driver, incident model.Incident, incidentID int64, repository model.Repository, channel *slack.Channel, warRoomURL string) {
-	postMortemURL, err := createPostMortem(ctx, logger, client, fileStorage, incidentID, channel.Name, repository, channel.Name)
+	postMortemURL, err := createPostMortem(ctx, logger, client, fileStorage, incidentID, incident.Title, repository, channel.Name)
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -29,6 +29,16 @@ func OpenStartIncidentDialog(client bot.Client, triggerID string) error {
 		})
 	}
 
+	incidentTitle := &slack.TextInputElement{
+		DialogInput: slack.DialogInput{
+			Label:       "Incident Title",
+			Name:        "incident_title",
+			Type:        "text",
+			Placeholder: "my-incident-title",
+		},
+		MaxLength: 22,
+	}
+
 	channelName := &slack.TextInputElement{
 		DialogInput: slack.DialogInput{
 			Label:       "Channel name",
@@ -119,6 +129,7 @@ func OpenStartIncidentDialog(client bot.Client, triggerID string) error {
 		SubmitLabel:    "Start",
 		NotifyOnCancel: false,
 		Elements: []slack.DialogElement{
+			incidentTitle,
 			channelName,
 			meeting,
 			severityLevel,
@@ -150,6 +161,7 @@ func StartIncidentByDialog(
 		now              = time.Now().UTC()
 		incidentAuthor   = incidentDetails.User.ID
 		submission       = incidentDetails.Submission
+		incidentTitle    = submission.IncidentTitle
 		channelName      = submission.ChannelName
 		warRoomURL       = submission.WarRoomURL
 		severityLevel    = submission.SeverityLevel
@@ -181,7 +193,7 @@ func StartIncidentByDialog(
 	incident := model.Incident{
 		ChannelName:             channelName,
 		ChannelId:               channel.ID,
-		Title:                   channelName,
+		Title:                   incidentTitle,
 		Product:                 product,
 		DescriptionStarted:      description,
 		Status:                  model.StatusOpen,


### PR DESCRIPTION
## Description 
This PR fixes the problem presented in this issue: https://github.com/ResultadosDigitais/hellper/issues/18
This PR change the dialog at the creation of an Incident. 
Before this refactor there was no field to enter the incident title at the dialog modal. 
After this changes the user will be asked to enter not only the channel name but also the incident title name. 

## How to test. 
1. Open an incident

### Expected Behavior.
The dialog modal should display a field that asks to the user to enter the incident name. 
![image](https://user-images.githubusercontent.com/44374637/89216555-fb8c9700-d5a0-11ea-8821-c181e45889ba.png)

In Addiction, the title of the PostMortem document should display the incident name instead of the channel incident name like is being shown in the image.
![image](https://user-images.githubusercontent.com/44374637/89216710-460e1380-d5a1-11ea-8f46-a071c052ba67.png)

Finally, the title field at the postgres should be filled with the incident name and not with the channel name. 
![image](https://user-images.githubusercontent.com/44374637/89216845-879ebe80-d5a1-11ea-876d-8c3e1363a682.png)


