### PR TITLE
feat: Persist incident cancelling data

### DIFF
--- a/internal/commands/cancel.go
+++ b/internal/commands/cancel.go
@@ -119,9 +119,13 @@ func CancelIncidentByDialog(
 		userID           = incidentDetails.User.ID
 		channelID        = incidentDetails.Channel.ID
 		description      = incidentDetails.Submission.IncidentDescription
+		requestCancel    = model.Incident{
+			ChannelId:            channelID,
+			DescriptionCancelled: description,
+		}
 	)
 
-	err := repository.CancelIncident(ctx, channelID, description)
+	err := repository.CancelIncident(ctx, &requestCancel)
 	if err != nil {
 		logger.Error(
 			ctx,

--- a/internal/model/repository.go
+++ b/internal/model/repository.go
@@ -7,7 +7,7 @@ type Repository interface {
 	InsertIncident(context.Context, *Incident) (int64, error)
 	GetIncident(context.Context, string) (Incident, error)
 	UpdateIncidentDates(context.Context, *Incident) error
-	CancelIncident(context.Context, string, string) error
+	CancelIncident(context.Context, *Incident) error
 	CloseIncident(context.Context, *Incident) error
 	ListActiveIncidents(context.Context) ([]Incident, error)
 	ResolveIncident(context.Context, *Incident) error

--- a/internal/model/repository_mock.go
+++ b/internal/model/repository_mock.go
@@ -40,8 +40,8 @@ func (mock *RepositoryMock) AddPostMortemUrl(ctx context.Context, channelName st
 	return args.Error(0)
 }
 
-func (mock *RepositoryMock) CancelIncident(ctx context.Context, channelID string, description string) error {
-	args := mock.Called(ctx, channelID, description)
+func (mock *RepositoryMock) CancelIncident(ctx context.Context, inc *Incident) error {
+	args := mock.Called(ctx, inc.ChannelId, inc.DescriptionCancelled)
 	return args.Error(0)
 }
 

--- a/internal/model/sql/postgres/repository.go
+++ b/internal/model/sql/postgres/repository.go
@@ -325,26 +325,26 @@ func (r *repository) UpdateIncidentDates(ctx context.Context, inc *model.Inciden
 	return nil
 }
 
-func (r *repository) CancelIncident(ctx context.Context, channelID string, description string) error {
+func (r *repository) CancelIncident(ctx context.Context, inc *model.Incident) error {
 	r.logger.Info(
 		ctx,
 		"postgres/repository.CancelIncident INFO",
-		log.NewValue("channelID", channelID),
-		log.NewValue("descriptionCancel", description),
+		log.NewValue("channelID", inc.ChannelId),
+		log.NewValue("descriptionCancel", inc.DescriptionCancelled),
 	)
 	result, err := r.db.Exec(
-		`UPDATE incident SET status = $1, description = $2 WHERE channel_id = $3`,
+		`UPDATE incident SET status = $1, description_cancelled = $2 WHERE channel_id = $3`,
 		model.StatusCancel,
-		description,
-		channelID,
+		inc.DescriptionCancelled,
+		inc.ChannelId,
 	)
 
 	if err != nil {
 		r.logger.Error(
 			ctx,
 			"postgres/repository.CancelIncident ERROR",
-			log.NewValue("channelID", channelID),
-			log.NewValue("description", description),
+			log.NewValue("channelID", inc.ChannelId),
+			log.NewValue("description", inc.DescriptionCancelled),
 			log.NewValue("error", err),
 		)
 		return err
@@ -356,8 +356,8 @@ func (r *repository) CancelIncident(ctx context.Context, channelID string, descr
 		r.logger.Error(
 			ctx,
 			"postgres/repository.CancelIncident ERROR",
-			log.NewValue("channelID", channelID),
-			log.NewValue("description", description),
+			log.NewValue("channelID", inc.ChannelId),
+			log.NewValue("description", inc.DescriptionCancelled),
 			log.NewValue("error", err),
 		)
 
@@ -369,8 +369,8 @@ func (r *repository) CancelIncident(ctx context.Context, channelID string, descr
 		r.logger.Error(
 			ctx,
 			"postgres/repository.CancelIncident ERROR",
-			log.NewValue("channelID", channelID),
-			log.NewValue("description", description),
+			log.NewValue("channelID", inc.ChannelId),
+			log.NewValue("description", inc.DescriptionCancelled),
 			log.NewValue("error", err),
 		)
 
@@ -380,8 +380,8 @@ func (r *repository) CancelIncident(ctx context.Context, channelID string, descr
 	r.logger.Info(
 		ctx,
 		"postgres/repository.CancelIncident SUCCESS",
-		log.NewValue("channelID", channelID),
-		log.NewValue("descriptionCancel", description),
+		log.NewValue("channelID", inc.ChannelId),
+		log.NewValue("descriptionCancel", inc.DescriptionCancelled),
 	)
 	return nil
 }


### PR DESCRIPTION
Description
Use model.Incident instead of using function parameters alone, and persist the description of the cancellation in the database.