### PR TITLE
add placeholder decription at close incident command team field

### DIFF
--- a/internal/commands/close.go
+++ b/internal/commands/close.go
@@ -115,7 +115,7 @@ func CloseIncidentDialog(ctx context.Context, logger log.Logger, client bot.Clie
 			Label:       "Owner team",
 			Name:        "owner_team",
 			Type:        "text",
-			Placeholder: "Team",
+			Placeholder: "Team (i.e. Mushin, Hydra, POPE)",
 			Optional:    false,
 		},
 	}


### PR DESCRIPTION
### Description

This PR just add a placeholder description at Team field, in incident_resolve command;

### How to test?
Just open and resolve a incident in Staging env;

### Expected behavior
The Placeholder at Team field into resolve command should be "Team (i.e. Mushin, Hydra, POPE)",