### PR TITLE
[HYDRA] Change max length of incidentTitle and ChannelName in Open Command

### DIFF
--- a/internal/commands/open.go
+++ b/internal/commands/open.go
@@ -36,7 +36,7 @@ func OpenStartIncidentDialog(client bot.Client, triggerID string) error {
 			Type:        "text",
 			Placeholder: "My Incident Title",
 		},
-		MaxLength: 22,
+		MaxLength: 100,
 	}
 
 	channelName := &slack.TextInputElement{
@@ -46,7 +46,7 @@ func OpenStartIncidentDialog(client bot.Client, triggerID string) error {
 			Type:        "text",
 			Placeholder: "inc-my-incident",
 		},
-		MaxLength: 22,
+		MaxLength: 30,
 	}
 
 	meeting := &slack.TextInputElement{


### PR DESCRIPTION
### Description
This PR changes the max length of the IncidentTitle and ChannelName.

### How to test?
Just setup your environment and create a new incidente with the new max length values;

### Expected behavior
The Slack Channel should be created without problems.