### PR TITLE
create catalog info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: hellper
+  annotations:
+    github.com/project-slug: ResultadosDigitais/hellper
+spec:
+  type: service
+  lifecycle: production
+  owner: hydra 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hellper
   annotations:
     github.com/project-slug: ResultadosDigitais/hellper
+    circleci.com/project-slug: github/ResultadosDigitais/hellper
 spec:
   type: service
   lifecycle: production


### PR DESCRIPTION
Contexto

Estamos mapeando os componentes da RD para dentro do Backstage e por isso precisamos deste arquivo yaml no mesmo diretório do componente. Dessa forma, o componente será listado no RD Station Catalog (https://backstage.production.rdops.systems/catalog) e terá uma página na qual constarão todas as informações pertinentes tais como descrição, links, owner, relações, informações sobre CI/CD, etc.

É possível consultar mais detalhes deste mapeamento aqui: https://github.com/ResultadosDigitais/designdoc/blob/master/enablers/devtools/fonte-da-verdade-artefatos.md