### PR TITLE
Atualiza dependabot pra não executar rebase automático

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
   - hydra
   labels:
   - dependabot
+  rebase-strategy: disabled


### PR DESCRIPTION
Muda configurações do dependabot pra não executar rebase automático.

Você pode continuar usando o rebase automatizado do dependabot através de comandos por comentários: https://docs.github.com/pt/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#gerenciando-pull-requests-dependabot-com-comandos-de-coment%C3%A1rio

Essa é uma iniciativa do [incidente 1334](https://docs.google.com/document/d/100POzoqWVOZivVDGwX_NpvPC4Qyplr3XHr28ECV0diM/edit).